### PR TITLE
Improve canvas features and prediction API

### DIFF
--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -220,6 +220,8 @@ class ImagePoolHandler {
         const projectId = this.stateManager.getActiveProjectId();
         if (!projectId) return;
 
+        this.Utils.dispatchCustomEvent('save-canvas-state', { imageHash: this.stateManager.getActiveImageHash() });
+
         this.latestImageRequestHash = imageHash;
         const requestedHash = imageHash;
 

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -105,6 +105,13 @@
                                 <input type="text" id="image-source-url-path" placeholder="http://.../img.jpg or .../list.txt">
                             </div>
                             <button id="add-image-source-btn">Add Source</button>
+                            <div class="file-upload-btn-container" style="margin-top:8px;">
+                                <label for="image-upload" class="file-upload-styled-btn">Load Image</label>
+                                <input type="file" id="image-upload" accept="image/*" multiple>
+                            </div>
+                            <div id="image-upload-progress" class="progress-bar-container">
+                                <div id="image-upload-bar" class="progress-bar-fill">0%</div>
+                            </div>
                             <div id="image-sources-list-container">
                                 <p><em>No sources added yet for this project.</em></p>
                             </div>
@@ -152,19 +159,9 @@
                 <div class="image-section">
                     <div class="canvas-toolbar">
                         <div class="toolbar-section">
-                            <div class="file-upload-btn-container">
-                                <label for="image-upload" class="file-upload-styled-btn">Load Image</label>
-                                <input type="file" id="image-upload" accept="image/*" multiple>
-                            </div>
-                            <div id="image-upload-progress" class="progress-bar-container">
-                                <div id="image-upload-bar" class="progress-bar-fill">0%</div>
-                            </div>
-                        </div>
-                        <div class="toolbar-section">
                             <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
                         </div>
                         <div class="toolbar-section">
-                            <label for="mask-display-mode">Display Mode:</label>
                             <select id="mask-display-mode" title="Choose how to display multiple predicted masks">
                                 <option value="best">Best Mask Only</option>
                                 <option value="all">All Masks</option>

--- a/docs/canvas_specification.md
+++ b/docs/canvas_specification.md
@@ -106,6 +106,7 @@ The canvas system employs a three-layer architecture with independent rendering 
 * Session-level: Opacity settings, display preferences
 * Image-level: User inputs, mask selections, toggle states
 * Temporary: Drawing states, interaction feedback
+* In-memory cache keyed by image hash stores recent canvas state to avoid large localStorage usage
 
 ---
 
@@ -211,7 +212,7 @@ Response: {
 * Base hue step: 360° / (mask_count * distribution_factor)
 * Saturation range: 70-90% for vibrant colors
 * Lightness range: 55-65% for optimal contrast
-* Alpha channel: 70% opacity as default
+* Alpha channel: 100% opacity for generated colors; layer transparency controlled by slider
 
 ### 4.3. Rendering Pipeline
 
@@ -258,6 +259,7 @@ Response: {
 * **Box Removal:** Click inside existing box or draw minimal box
 * **Real-time Preview:** Show box outline during drag operation
 * **Constraint Handling:** Ensure minimum box size for meaningful input
+* **Multiple Boxes:** Several boxes can be drawn concurrently; each is kept until manually removed
 
 **Polygon Drawing:**
 * **Lasso Mode (Ctrl + Drag):** Draw freeform polygon regions

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -23,6 +23,7 @@
   - A URI/ BLOB datastore reference (Support for Azure context). 
     - Credentials can be set up in the UI by the client, or via an environment variable, from the server runtime, or the server can attempt to use the default credentials which may work if the server is being run from an azure compuute instance.
 - Multiple images/ image sources can be added to the pool of images.
+- Manual uploads are initiated from the **Load Image** button now located inside the Image Sources section.
 - The client can review and manage (add/remove/edit) sources currently in the pool, and also single images from any of the sources. The server will keep a registry with 
 - Images in the pool will not be loaded by the server runtime yet, but for images uploaded by the client, they will be stored on the server in a folder, "uploads", or another destination folder specified by the server.
 - The user can step through the images in the pool, and create the masks for each image, interacting woth the canvas until having reached the desired masks. Then the user can step on to the next image in the pool. 


### PR DESCRIPTION
## Summary
- support caching and state restoration for canvas
- enable multiple boxes in canvas inputs and payloads
- move upload button to image sources section
- allow full-opacity mask colors and fix opacity slider
- document new opacity behavior, multiple boxes, and load image relocation

## Testing
- `python -m py_compile app/backend/sam_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_6841f6b24750832099855a3464955c96