### PR TITLE
Add project overlay with persistence

### DIFF
--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -147,6 +147,8 @@ def list_existing_projects() -> List[Dict[str, Any]]:
             "name": info.get("project_name", "Unknown Project"),
             "last_modified": info.get("last_modified_at_content", info.get("created_at"))
         })
+
+    projects_info.sort(key=lambda p: p.get("last_modified") or "", reverse=True)
     return projects_info
 
 def load_project_by_id(project_id: str) -> Optional[Dict[str, Any]]:

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -212,12 +212,18 @@ def get_current_model_for_project(project_id: str, sam_inference: SAMInference) 
 
     if need_reload and (model_path or model_key):
         print(f"Loading model for project {project_id} from stored settings...")
-        sam_inference.load_model(
-            model_size_key=model_key,
-            model_path_override=model_path,
-            config_path_override=config_path,
-            apply_postprocessing=apply_postprocessing
-        )
+        if model_key:
+            sam_inference.load_model(
+                model_size_key=model_key,
+                config_path_override=config_path,
+                apply_postprocessing=apply_postprocessing
+            )
+        else:
+            sam_inference.load_model(
+                model_path_override=model_path,
+                config_path_override=config_path,
+                apply_postprocessing=apply_postprocessing
+            )
 
     return sam_inference.get_model_info()
 

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -107,6 +107,36 @@ def api_get_active_project():
     project_name = db_manager.get_project_name(project_id)
     return jsonify({"success": True, "project_id": project_id, "project_name": project_name})
 
+# Endpoint to retrieve overall session state (project, model, image)
+@app.route('/api/session', methods=['GET'])
+def api_get_session_state():
+    project_id = get_active_project_id()
+    project_name = db_manager.get_project_name(project_id) if project_id else None
+
+    model_info = sam_inference_instance.get_model_info()
+
+    active_image = None
+    if project_id and sam_inference_instance.image_hash:
+        img_info = db_manager.get_image_by_hash(project_id, sam_inference_instance.image_hash)
+        if img_info:
+            active_image = {
+                "image_hash": sam_inference_instance.image_hash,
+                "filename": img_info.get("original_filename"),
+                "width": img_info.get("width"),
+                "height": img_info.get("height"),
+                "status": img_info.get("status"),
+                "image_data": sam_inference_instance.get_image_as_base64(),
+                "masks": db_manager.get_mask_layers_for_image(project_id, sam_inference_instance.image_hash)
+            }
+
+    return jsonify({
+        "success": True,
+        "project_id": project_id,
+        "project_name": project_name,
+        "model_info": model_info,
+        "active_image": active_image
+    })
+
 @app.route('/api/project/load', methods=['POST'])
 def api_load_project():
     data = request.json

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -98,6 +98,15 @@ def api_list_projects():
     projects = project_logic.list_existing_projects()
     return jsonify({"success": True, "projects": projects})
 
+# New endpoint: get currently active project
+@app.route('/api/project/active', methods=['GET'])
+def api_get_active_project():
+    project_id = get_active_project_id()
+    if not project_id:
+        return jsonify({"success": True, "project_id": None, "project_name": None})
+    project_name = db_manager.get_project_name(project_id)
+    return jsonify({"success": True, "project_id": project_id, "project_name": project_name})
+
 @app.route('/api/project/load', methods=['POST'])
 def api_load_project():
     data = request.json

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -566,3 +566,33 @@ input[type="file"]#image-upload {
     .image-pool-controls, .image-pool-filters { flex-direction: column; align-items: stretch;}
     .image-pool-controls button, .image-pool-filters button, .image-pool-filters select { width: 100%; }
 }
+
+/* Modal Overlay for Project Management */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    max-height: 90%;
+    overflow-y: auto;
+}
+
+.modal-close {
+    float: right;
+    font-size: 20px;
+    border: none;
+    background: none;
+    cursor: pointer;
+}

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -98,6 +98,9 @@ class APIClient {
     async listProjects() {
         return this._request('/projects');
     }
+    async getActiveProject() {
+        return this._request('/project/active');
+    }
     async loadProject(projectId) {
         return this._request('/project/load', 'POST', { project_id: projectId });
     }

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -101,6 +101,9 @@ class APIClient {
     async getActiveProject() {
         return this._request('/project/active');
     }
+    async getSessionState() {
+        return this._request('/session');
+    }
     async loadProject(projectId) {
         return this._request('/project/load', 'POST', { project_id: projectId });
     }

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -151,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    document.addEventListener('project-loaded', (event) => {
+    document.addEventListener('project-loaded', async (event) => {
         const { projectId, projectName, projectData } = event.detail;
         uiManager.showGlobalStatus(`Project '${utils.escapeHTML(projectName)}' loaded.`, 'success');
         canvasManager.clearAllCanvasInputs(true);
@@ -165,6 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
             applyPostprocessing: settings.current_sam_apply_postprocessing === 'true'
         });
         if (imagePoolHandler) imagePoolHandler.loadAndDisplayImagePool();
+        await restoreSessionFromServer();
     });
 
     document.addEventListener('project-load-failed', (event) => {

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -94,6 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             const data = await apiClient.getSessionState();
             if (!data.success) return;
+
             if (data.model_info) {
                 stateManager.setCurrentLoadedModel(data.model_info);
                 utils.dispatchCustomEvent('project-model-settings-update', {
@@ -102,7 +103,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     configPath: data.model_info.config_path,
                     applyPostprocessing: data.model_info.apply_postprocessing
                 });
+
+                if (data.model_info.loaded) {
+                    utils.dispatchCustomEvent('model-load-success', {
+                        model_info: data.model_info,
+                        message: 'Model ready.'
+                    });
+                }
             }
+
             if (data.active_image) {
                 stateManager.setActiveImage(data.active_image.image_hash, data.active_image.filename);
                 utils.dispatchCustomEvent('active-image-set', {

--- a/app/frontend/static/js/projectHandler.js
+++ b/app/frontend/static/js/projectHandler.js
@@ -181,6 +181,7 @@ class ProjectHandler {
             if (data.success) {
                 this.elements.loadProjectSelect.innerHTML = '<option value="">Select a project to load...</option>';
                 if (data.projects && data.projects.length > 0) {
+                    data.projects.sort((a,b) => new Date(b.last_modified) - new Date(a.last_modified));
                     data.projects.forEach(p => {
                         const option = document.createElement('option');
                         option.value = p.id;

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -54,13 +54,17 @@
                     </div>
                 </div>
 
-                <div class="expandable-section" id="project-management-expandable">
+                <div class="expandable-section" id="project-management-bar">
                     <div class="expandable-header">
-                        <span>Project Management</span>
+                        <span>Project</span>
                         <span id="active-project-display" class="project-status-inline">No active project</span>
-                        <span class="expand-indicator">▼</span>
                     </div>
-                    <div class="expandable-content collapsed">
+                </div>
+
+                <div id="project-management-overlay" class="modal-overlay" style="display:none;">
+                    <div class="modal-content project-modal">
+                        <button id="close-project-overlay" class="modal-close">&times;</button>
+                        <h3>Project Management</h3>
                         <div class="project-controls">
                             <h4>Create New Project</h4>
                             <div class="input-group">

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -117,7 +117,7 @@ The system will employ a client-server architecture.
     *   **Server (Upload DB):** Saves the DB file, validates it, sets it as active.
     *   **Server Response (Upload DB):** `{"success": true, "project_data": {...}}`
 *   **Client:** Loads project data into UI.
-*   **Server:** Automatically loads the project's last used SAM model and post-processing setting, replacing any currently loaded model if different.
+*   **Server:** Automatically loads the project's last used SAM model and post-processing setting, replacing any currently loaded model if different. When the model was selected via one of the predefined size keys the key is stored as well so it can be chosen again when the project is loaded.
 *   **Client:** After a project is loaded it queries `/api/session` to refresh the current model and image state.
 *   **Client Request (Get Active):** On page refresh the client calls `GET /api/session` to retrieve the current project, model, and image so the UI can restore the session. If no project is active, the project management overlay is shown.
 *   **Save Project (Implicit):** Changes are saved to the Project State DB as they occur (e.g., after mask generation, image status update).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -116,7 +116,9 @@ The system will employ a client-server architecture.
     *   **Client Request (Upload DB):** `POST /api/project/upload_db` (Multipart form with DB file)
     *   **Server (Upload DB):** Saves the DB file, validates it, sets it as active.
     *   **Server Response (Upload DB):** `{"success": true, "project_data": {...}}`
-    *   **Client:** Loads project data into UI.
+*   **Client:** Loads project data into UI.
+*   **Server:** Automatically loads the project's last used SAM model and post-processing setting if not already active.
+*   **Client Request (Get Active):** On page refresh the client calls `GET /api/project/active` to retrieve the current active project. If a project is returned, the UI resumes that session; otherwise the project management overlay is shown.
 *   **Save Project (Implicit):** Changes are saved to the Project State DB as they occur (e.g., after mask generation, image status update).
 *   **Download Project State DB:**
     *   **Client:** User clicks "Download Project Data."
@@ -288,6 +290,7 @@ The system will employ a client-server architecture.
 **Project Management:**
 *   `POST /api/project` (Create)
 *   `GET /api/projects` (List)
+*   `GET /api/project/active` (Get active project)
 *   `POST /api/project/load` (Load by ID)
 *   `POST /api/project/upload_db` (Upload DB file to load)
 *   `GET /api/project/download_db?project_id=<uuid>` (Download DB file)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -117,8 +117,8 @@ The system will employ a client-server architecture.
     *   **Server (Upload DB):** Saves the DB file, validates it, sets it as active.
     *   **Server Response (Upload DB):** `{"success": true, "project_data": {...}}`
 *   **Client:** Loads project data into UI.
-*   **Server:** Automatically loads the project's last used SAM model and post-processing setting if not already active.
-*   **Client Request (Get Active):** On page refresh the client calls `GET /api/project/active` to retrieve the current active project. If a project is returned, the UI resumes that session; otherwise the project management overlay is shown.
+*   **Server:** Automatically loads the project's last used SAM model and post-processing setting, replacing any currently loaded model if different.
+*   **Client Request (Get Active):** On page refresh the client calls `GET /api/session` to retrieve the current project, model, and image so the UI can restore the session. If no project is active, the project management overlay is shown.
 *   **Save Project (Implicit):** Changes are saved to the Project State DB as they occur (e.g., after mask generation, image status update).
 *   **Download Project State DB:**
     *   **Client:** User clicks "Download Project Data."
@@ -291,6 +291,7 @@ The system will employ a client-server architecture.
 *   `POST /api/project` (Create)
 *   `GET /api/projects` (List)
 *   `GET /api/project/active` (Get active project)
+*   `GET /api/session` (Current project, model, and image)
 *   `POST /api/project/load` (Load by ID)
 *   `POST /api/project/upload_db` (Upload DB file to load)
 *   `GET /api/project/download_db?project_id=<uuid>` (Download DB file)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -108,7 +108,7 @@ The system will employ a client-server architecture.
 *   **Load Existing Project:**
     *   **Client:** User selects from a list of existing projects (server lists available DB files) or uploads a project state DB file.
     *   **Client Request (List):** `GET /api/projects`
-    *   **Server (List):** Scans `projects_data` directory for valid DB files.
+    *   **Server (List):** Scans `projects_data` for valid DB files and returns them ordered by most recently used.
     *   **Server Response (List):** `{"success": true, "projects": [{"id": "uuid", "name": "my_project", "last_modified": "timestamp"}, ...]}`
     *   **Client Request (Load by ID):** `POST /api/project/load` (Body: `{"project_id": "uuid"}`)
     *   **Server (Load by ID):** Sets the active project ID, validates the DB.
@@ -118,6 +118,7 @@ The system will employ a client-server architecture.
     *   **Server Response (Upload DB):** `{"success": true, "project_data": {...}}`
 *   **Client:** Loads project data into UI.
 *   **Server:** Automatically loads the project's last used SAM model and post-processing setting, replacing any currently loaded model if different.
+*   **Client:** After a project is loaded it queries `/api/session` to refresh the current model and image state.
 *   **Client Request (Get Active):** On page refresh the client calls `GET /api/session` to retrieve the current project, model, and image so the UI can restore the session. If no project is active, the project management overlay is shown.
 *   **Save Project (Implicit):** Changes are saved to the Project State DB as they occur (e.g., after mask generation, image status update).
 *   **Download Project State DB:**

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -23,6 +23,7 @@
 * Overlay opens automatically when no project is active and closes after loading or creating a project.
 * The client now calls the server for full session state on page reload using `/api/session`, restoring the project, model and active image automatically. After loading a project the session state is refreshed as well so the model is ready without an extra click.
 * Restoring session state also dispatches a `model-load-success` event so the canvas recognizes the loaded model without manual intervention.
+* The selected model key (if any) is stored with the project so the same dropdown option is chosen again when the project is reloaded. Custom paths are only used when no key was selected.
 
 ## Model Configuration
 * Make the model selection as an overlay on the page, which fades the background. Like a popup dialogue on page. This popup can be shown by clicking on the "Load Model" button-bar (this bar will show the currently loaded model, staying in sync even on page reload.)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,7 +21,7 @@
 ## Project Management
 * Implemented project management as a modal overlay triggered by the "Project" bar.
 * Overlay opens automatically when no project is active and closes after loading or creating a project.
-* The client now calls the server for full session state on page reload using `/api/session`, restoring the project, model and active image automatically.
+* The client now calls the server for full session state on page reload using `/api/session`, restoring the project, model and active image automatically. After loading a project the session state is refreshed as well so the model is ready without an extra click.
 
 ## Model Configuration
 * Make the model selection as an overlay on the page, which fades the background. Like a popup dialogue on page. This popup can be shown by clicking on the "Load Model" button-bar (this bar will show the currently loaded model, staying in sync even on page reload.)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,7 +21,7 @@
 ## Project Management
 * Implemented project management as a modal overlay triggered by the "Project" bar.
 * Overlay opens automatically when no project is active and closes after loading or creating a project.
-* The client now calls the server for the active project on page reload so the session is restored.
+* The client now calls the server for full session state on page reload using `/api/session`, restoring the project, model and active image automatically.
 
 ## Model Configuration
 * Make the model selection as an overlay on the page, which fades the background. Like a popup dialogue on page. This popup can be shown by clicking on the "Load Model" button-bar (this bar will show the currently loaded model, staying in sync even on page reload.)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,9 +19,9 @@
 
 
 ## Project Management
-* Make the project management as a an overlay on the page, which fades the background. Like a popup dialogue on page. This popup can be shown by clicking on the "Project" button.
-* If no project is loaded, the popup overlay will be shown automatically. (For example on first page load after server start, we start by showing the project Manager overlay)
-* When reloading the page, we will get the active project from the server, so we don't loose the state, and can continue working with the session that we had before reloading.
+* Implemented project management as a modal overlay triggered by the "Project" bar.
+* Overlay opens automatically when no project is active and closes after loading or creating a project.
+* The client now calls the server for the active project on page reload so the session is restored.
 
 ## Model Configuration
 * Make the model selection as an overlay on the page, which fades the background. Like a popup dialogue on page. This popup can be shown by clicking on the "Load Model" button-bar (this bar will show the currently loaded model, staying in sync even on page reload.)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,6 +22,7 @@
 * Implemented project management as a modal overlay triggered by the "Project" bar.
 * Overlay opens automatically when no project is active and closes after loading or creating a project.
 * The client now calls the server for full session state on page reload using `/api/session`, restoring the project, model and active image automatically. After loading a project the session state is refreshed as well so the model is ready without an extra click.
+* Restoring session state also dispatches a `model-load-success` event so the canvas recognizes the loaded model without manual intervention.
 
 ## Model Configuration
 * Make the model selection as an overlay on the page, which fades the background. Like a popup dialogue on page. This popup can be shown by clicking on the "Load Model" button-bar (this bar will show the currently loaded model, staying in sync even on page reload.)


### PR DESCRIPTION
## Summary
- implement new endpoint `/api/project/active`
- expose API client helper `getActiveProject`
- redesign project management UI as modal overlay
- auto show overlay when no project active and restore active project on reload
- style modal overlay
- document API and behaviour changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68442a1d39f08320b32871b7f68684e7