### PR TITLE
Add image source management overlay

### DIFF
--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -384,8 +384,6 @@ def api_exempt_source_image(project_id, source_id):
         return jsonify({"success": False, "error": "Source not found for image."}), 400
     try:
         db_manager.set_image_exemption(project_id, source_id, image_hash, exempt)
-        if exempt:
-            db_manager.delete_image_from_pool(project_id, image_hash)
         return jsonify({"success": True})
     except Exception as e:
         app.logger.error(f"Error setting image exemption: {e}")

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -269,9 +269,9 @@ header p {
 #create-project-btn:hover:not(:disabled) { background-color: #218838; }
 
 .source-input-group { /* For folder path, URL path, etc. */
-    display: flex; /* Overrides display:none from HTML when shown */
-    flex-direction: column; /* Stack label and input */
-    width: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 180px;
     gap: 5px;
     margin-bottom: 10px;
     padding: 10px;
@@ -595,4 +595,25 @@ input[type="file"]#image-upload {
     border: none;
     background: none;
     cursor: pointer;
+}
+
+.source-modal {
+    width: 80%;
+}
+
+.source-inputs-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    margin-bottom: 15px;
+}
+
+.sources-tree-list {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: 10px;
+    border: 1px solid #e9ecef;
+    background-color: #f8f9fa;
+    border-radius: 4px;
 }

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -367,6 +367,7 @@ ul.image-sources-list li span { flex-grow: 1; }
 #image-gallery-container p em { color: #6c757d; text-align: center; width: 100%; }
 
 .image-card {
+    position: relative;
     background-color: #fff;
     border: 1px solid #ddd;
     border-radius: 4px;
@@ -415,6 +416,23 @@ ul.image-sources-list li span { flex-grow: 1; }
 .image-status-badge.in_progress_manual, .image-status-badge.in_progress_auto { background-color: #ffc107; color: #333; }
 .image-status-badge.completed { background-color: #28a745; }
 .image-status-badge.unknown { background-color: #adb5bd; }
+
+.delete-image-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background-color: #dc3545;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 18px;
+    height: 18px;
+    line-height: 16px;
+    font-size: 12px;
+    display: none;
+    cursor: pointer;
+}
+.image-card:hover .delete-image-btn { display: block; }
 
 
 /* File Upload Button (general styling) */
@@ -616,4 +634,28 @@ input[type="file"]#image-upload {
     border: 1px solid #e9ecef;
     background-color: #f8f9fa;
     border-radius: 4px;
+    width: 100%;
+}
+
+.sources-tree-list details {
+    border-bottom: 1px dashed #ccc;
+    padding: 4px 0;
+}
+.sources-tree-list summary {
+    cursor: pointer;
+    font-weight: 500;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.sources-tree-list ul {
+    list-style: none;
+    padding-left: 20px;
+    margin: 4px 0;
+}
+.sources-tree-list li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
 }

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -154,6 +154,12 @@ class APIClient {
     async removeImageSource(projectId, sourceId) {
         return this._request(`/project/${projectId}/sources/${sourceId}`, 'DELETE');
     }
+    async listImagesForSource(projectId, sourceId) {
+        return this._request(`/project/${projectId}/sources/${sourceId}/images`);
+    }
+    async setImageExempt(projectId, sourceId, imageHash, exempt=true) {
+        return this._request(`/project/${projectId}/sources/${sourceId}/exempt_image`, 'POST', { image_hash: imageHash, exempt });
+    }
     async listImages(projectId, page = 1, perPage = 50, statusFilter = null) {
         let query = `?page=${page}&per_page=${perPage}`;
         if (statusFilter) query += `&status_filter=${statusFilter}`;

--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -314,14 +314,14 @@ class ImagePoolHandler {
     }
 
     async handleDeleteImage(imageHash) {
-        if (!confirm('Remove this image from the pool?')) return;
+        if (!confirm('Exclude this image from the pool?')) return;
         const projectId = this.stateManager.getActiveProjectId();
         if (!projectId) return;
         this.uiManager.showGlobalStatus('Removing image...', 'loading', 0);
         try {
             const data = await this.apiClient.setImageExempt(projectId, null, imageHash, true);
             if (data.success) {
-                this.uiManager.showGlobalStatus('Image removed.', 'success', 2000);
+                this.uiManager.showGlobalStatus('Image excluded.', 'success', 2000);
                 this.loadAndDisplayImagePool(this.currentPage, this.currentStatusFilter);
                 this.Utils.dispatchCustomEvent('sources-updated', {});
             } else {

--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -165,7 +165,11 @@ class ImagePoolHandler {
         const thumb = document.createElement('img');
         thumb.src = this.apiClient.getImageThumbnailUrl(this.stateManager.getActiveProjectId(), imgData.image_hash);
         thumb.alt = this.Utils.escapeHTML(imgData.original_filename) || 'Image Thumbnail';
-        thumb.onerror = () => { thumb.src = "{{ url_for('static', filename='assets/placeholder_thumb.png') }}"; }; // Placeholder path
+        thumb.onerror = () => {
+            if (thumb.src.indexOf('placeholder_thumb.png') === -1) {
+                thumb.src = '/static/assets/placeholder_thumb.png';
+            }
+        };
 
         const name = document.createElement('p');
         name.className = 'image-card-name';

--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -182,6 +182,16 @@ class ImagePoolHandler {
         status.textContent = (imgData.status || 'unknown').replace(/_/g, ' ');
         status.title = `Status: ${status.textContent}`;
 
+        const delBtn = document.createElement('button');
+        delBtn.className = 'delete-image-btn';
+        delBtn.textContent = '×';
+        delBtn.title = 'Remove image from pool';
+        delBtn.onclick = (e) => {
+            e.stopPropagation();
+            this.handleDeleteImage(imgData.image_hash);
+        };
+
+        card.appendChild(delBtn);
         card.appendChild(thumb);
         card.appendChild(name);
         card.appendChild(status);
@@ -300,6 +310,25 @@ class ImagePoolHandler {
             }
         } catch (error) {
             this.uiManager.showGlobalStatus(`Error updating status: ${error.message}`, 'error');
+        }
+    }
+
+    async handleDeleteImage(imageHash) {
+        if (!confirm('Remove this image from the pool?')) return;
+        const projectId = this.stateManager.getActiveProjectId();
+        if (!projectId) return;
+        this.uiManager.showGlobalStatus('Removing image...', 'loading', 0);
+        try {
+            const data = await this.apiClient.setImageExempt(projectId, null, imageHash, true);
+            if (data.success) {
+                this.uiManager.showGlobalStatus('Image removed.', 'success', 2000);
+                this.loadAndDisplayImagePool(this.currentPage, this.currentStatusFilter);
+                this.Utils.dispatchCustomEvent('sources-updated', {});
+            } else {
+                throw new Error(data.error || 'Failed to remove image');
+            }
+        } catch (error) {
+            this.uiManager.showGlobalStatus(`Error removing image: ${error.message}`, 'error');
         }
     }
 

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -99,8 +99,10 @@
                         <h3>Manage Image Sources</h3>
                         <div class="source-inputs-row">
                             <div class="source-input-group">
-                                <label for="image-upload" class="file-upload-styled-btn">Upload</label>
-                                <input type="file" id="image-upload" accept="image/*" multiple>
+                                <div class="file-upload-btn-container">
+                                    <label for="image-upload" class="file-upload-styled-btn">Upload</label>
+                                    <input type="file" id="image-upload" accept="image/*" multiple>
+                                </div>
                                 <div id="image-upload-progress" class="progress-bar-container">
                                     <div id="image-upload-bar" class="progress-bar-fill">0%</div>
                                 </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -89,36 +89,40 @@
                             <div class="input-group">
                                 <button id="download-project-db-btn" title="Download current project data as SQLite file">Download Project DB</button>
                             </div>
-                            <hr>
-                            <h4>Image Sources (Current Project)</h4>
-                            <div class="input-group">
-                                <label for="image-source-type-select">Add Type:</label>
-                                <select id="image-source-type-select">
-                                    <option value="upload">Upload Files (via Canvas 'Load Image')</option>
-                                    <option value="folder">Server Folder Path</option>
-                                    <option value="url">Image URL or List URL</option>
-                                    <!-- <option value="azure">Azure Blob URI</option> -->
-                                </select>
-                            </div>
-                            <div id="image-source-folder-inputs" class="source-input-group" style="display:none;">
-                                <label for="image-source-folder-path">Folder Path:</label>
-                                <input type="text" id="image-source-folder-path" placeholder="/path/on/server/to/images">
-                            </div>
-                            <div id="image-source-url-inputs" class="source-input-group" style="display:none;">
-                                <label for="image-source-url-path">Image/List URL:</label>
-                                <input type="text" id="image-source-url-path" placeholder="http://.../img.jpg or .../list.txt">
-                            </div>
-                            <button id="add-image-source-btn">Add Source</button>
-                            <div class="file-upload-btn-container" style="margin-top:8px;">
-                                <label for="image-upload" class="file-upload-styled-btn">Load Image</label>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="source-management-overlay" class="modal-overlay" style="display:none;">
+                    <div class="modal-content source-modal">
+                        <button id="close-source-overlay" class="modal-close">&times;</button>
+                        <h3>Manage Image Sources</h3>
+                        <div class="source-inputs-row">
+                            <div class="source-input-group">
+                                <label for="image-upload" class="file-upload-styled-btn">Upload</label>
                                 <input type="file" id="image-upload" accept="image/*" multiple>
+                                <div id="image-upload-progress" class="progress-bar-container">
+                                    <div id="image-upload-bar" class="progress-bar-fill">0%</div>
+                                </div>
                             </div>
-                            <div id="image-upload-progress" class="progress-bar-container">
-                                <div id="image-upload-bar" class="progress-bar-fill">0%</div>
+                            <div class="source-input-group">
+                                <label for="image-source-folder-path">Server Folder:</label>
+                                <input type="text" id="image-source-folder-path" placeholder="/path/on/server/to/images">
+                                <button id="add-folder-source-btn">Add</button>
                             </div>
-                            <div id="image-sources-list-container">
-                                <p><em>No sources added yet for this project.</em></p>
+                            <div class="source-input-group">
+                                <label for="image-source-url-path">URL:</label>
+                                <input type="text" id="image-source-url-path" placeholder="http://.../img.jpg or .../list.txt">
+                                <button id="add-url-source-btn">Add</button>
                             </div>
+                            <div class="source-input-group">
+                                <label for="image-source-azure-uri">Azure URI/Blob:</label>
+                                <input type="text" id="image-source-azure-uri" placeholder="https://...">
+                                <button id="add-azure-source-btn">Add</button>
+                            </div>
+                        </div>
+                        <div id="image-sources-list-container" class="sources-tree-list">
+                            <p><em>No sources added yet for this project.</em></p>
                         </div>
                     </div>
                 </div>
@@ -146,6 +150,7 @@
                                 <option value="completed">Completed</option>
                             </select>
                             <button id="refresh-image-pool-btn">Refresh Pool</button>
+                            <button id="manage-sources-btn">Manage Sources</button>
                         </div>
                         <div id="image-gallery-container">
                             <p><em>Load a project to see images.</em></p>


### PR DESCRIPTION
## Summary
- introduce a wide Source Management modal
- show Upload/Folder/URL/Azure inputs in a row
- add Manage Sources button on image pool
- update ProjectHandler to control new modal
- fallback to placeholder thumbnail on error

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844555264648320bc3b646158abdf1b