### PR TITLE
Refactor AutoMask into modal overlay

### DIFF
--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -15,7 +15,12 @@
     box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
-.toolbar-col {
+.toolbar-col,
+.toolbar-col-1,
+.toolbar-col-2,
+.toolbar-col-3,
+.toolbar-col-4,
+.toolbar-col-5 {
     display: flex;
     align-items: center;
     gap: 10px;
@@ -245,7 +250,12 @@
     .canvas-toolbar {
         grid-template-columns: 1fr;
     }
-    .toolbar-col {
+    .toolbar-col,
+    .toolbar-col-1,
+    .toolbar-col-2,
+    .toolbar-col-3,
+    .toolbar-col-4,
+    .toolbar-col-5 {
         flex-direction: column;
         align-items: stretch;
     }

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -4,13 +4,14 @@
 /* Canvas Toolbar (specific to canvas interactions) */
 .canvas-toolbar {
     display: grid;
-    grid-template-columns: 10% 30% 15% 30% 10%; /* Make room for gap */
+    grid-template-columns: 10% 30% 20% 30% 5%; /* Make room for gap */
     gap: 10px;
     padding: 10px 15px;
     background-color: #f8f9fa;
     border-radius: 6px;
     margin-bottom: 15px;
     align-items: center;
+    justify-content: center;
     border: 1px solid #e9ecef;
     box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
@@ -23,6 +24,7 @@
 .toolbar-col-5 {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 10px;
 }
 

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -4,7 +4,7 @@
 /* Canvas Toolbar (specific to canvas interactions) */
 .canvas-toolbar {
     display: grid;
-    grid-template-columns: 10% 30% 20% 30% 10%;
+    grid-template-columns: 10% 30% 15% 30% 10%; /* Make room for gap */
     gap: 10px;
     padding: 10px 15px;
     background-color: #f8f9fa;
@@ -37,6 +37,7 @@
     display: flex;
     gap: 6px;
     align-items: center;
+    justify-content: center;
     flex-wrap: wrap;
 }
 
@@ -54,6 +55,8 @@
     display: flex;
     gap: 15px; /* Spacing between individual opacity controls */
     flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
 }
 
 .opacity-control {

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -3,8 +3,8 @@
 
 /* Canvas Toolbar (specific to canvas interactions) */
 .canvas-toolbar {
-    display: flex;
-    flex-wrap: wrap; /* Allow items to wrap */
+    display: grid;
+    grid-template-columns: 10% 30% 20% 30% 10%;
     gap: 10px;
     padding: 10px 15px;
     background-color: #f8f9fa;
@@ -15,10 +15,15 @@
     box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
-.toolbar-section { /* For grouping items like mode select and clear button */
+.toolbar-col {
     display: flex;
     align-items: center;
-    gap: 10px; /* Gap within a section */
+    gap: 10px;
+}
+
+.left-controls {
+    flex-direction: column;
+    align-items: stretch;
 }
 
 
@@ -44,7 +49,6 @@
     display: flex;
     gap: 15px; /* Spacing between individual opacity controls */
     flex-wrap: wrap;
-    margin-left: auto; /* Push to the right side of the toolbar */
 }
 
 .opacity-control {
@@ -239,24 +243,22 @@
 /* Responsive adjustments for canvas toolbar */
 @media (max-width: 768px) {
     .canvas-toolbar {
-        flex-direction: column;
-        align-items: stretch; /* Make toolbar items take full width */
+        grid-template-columns: 1fr;
     }
-    .toolbar-section {
+    .toolbar-col {
         flex-direction: column;
         align-items: stretch;
     }
     .opacity-controls {
-        margin-left: 0;
-        justify-content: space-between; /* Spread out opacity controls */
+        justify-content: space-between;
         width: 100%;
     }
     .opacity-control {
-        flex-grow: 1; /* Allow opacity controls to share space */
-        min-width: 120px; /* Ensure they don't get too squished */
+        flex-grow: 1;
+        min-width: 120px;
     }
     .opacity-control input[type="range"] {
-        width: 100%; /* Full width sliders */
+        width: 100%;
     }
     .canvas-container {
         min-height: 300px; /* Adjust min-height for smaller screens */

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -592,7 +592,7 @@ input[type="file"]#image-upload {
 }
 
 /* Help icon and tooltip styles */
-.help-section { position: relative; display: flex; align-items: center; margin-left: auto; }
+.help-section { position: relative; display: flex; align-items: center; justify-content: flex-end; }
 .help-icon {
     display: inline-block; width: 24px; height: 24px; background-color: #007bff; color: white;
     border-radius: 50%; text-align: center; line-height: 24px; font-size: 14px;
@@ -740,6 +740,11 @@ input[type="file"]#image-upload {
     max-width: 640px;
     overflow: hidden;
     white-space: nowrap;
+}
+
+.auto-mask-modal {
+    width: 40%;
+    max-width: 520px;
 }
 
 .source-inputs-row {

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -592,7 +592,7 @@ input[type="file"]#image-upload {
 }
 
 /* Help icon and tooltip styles */
-.help-section { position: relative; display: flex; align-items: center; justify-content: flex-end; }
+.help-section { position: relative; display: flex; align-items: center; justify-content: center; }
 .help-icon {
     display: inline-block; width: 24px; height: 24px; background-color: #007bff; color: white;
     border-radius: 50%; text-align: center; line-height: 24px; font-size: 14px;

--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -269,8 +269,6 @@ class CanvasManager {
             }
 
             this.renderMaskToggleControls();
-
-            this.renderMaskToggleControls();
         }
         this.automaskPredictions = []; // Clear automasks when manual predictions come in
         this.drawPredictionMaskLayer();
@@ -786,31 +784,47 @@ class CanvasManager {
             return;
         }
 
-        if (this.currentPredictionMultiBox || !this.manualPredictions || this.manualPredictions.length === 0) {
+        if (!this.manualPredictions || this.manualPredictions.length === 0) {
             this.maskToggleContainer.style.display = 'none';
             return;
         }
 
         this.maskToggleContainer.style.display = 'flex';
-        const labels = ['High', 'Medium', 'Low'];
-        this.manualPredictions.forEach((pred, idx) => {
-            const label = document.createElement('label');
-            const rb = document.createElement('input');
-            rb.type = 'radio';
-            rb.name = 'mask-select';
-            rb.value = idx;
-            rb.checked = pred.visible !== false;
-            rb.addEventListener('change', () => {
-                if (rb.checked) {
-                    this.selectedManualMaskIndex = idx;
-                    this.manualPredictions.forEach((p, i) => { p.visible = i === idx; });
+        if (this.currentPredictionMultiBox) {
+            this.manualPredictions.forEach((pred, idx) => {
+                const label = document.createElement('label');
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.checked = pred.visible !== false;
+                cb.addEventListener('change', () => {
+                    pred.visible = cb.checked;
                     this.drawPredictionMaskLayer();
-                }
+                });
+                label.appendChild(cb);
+                label.appendChild(document.createTextNode(`M${idx + 1}`));
+                this.maskToggleContainer.appendChild(label);
             });
-            label.appendChild(rb);
-            label.appendChild(document.createTextNode(labels[idx] || `M${idx + 1}`));
-            this.maskToggleContainer.appendChild(label);
-        });
+        } else {
+            const labels = ['High', 'Medium', 'Low'];
+            this.manualPredictions.forEach((pred, idx) => {
+                const label = document.createElement('label');
+                const rb = document.createElement('input');
+                rb.type = 'radio';
+                rb.name = 'mask-select';
+                rb.value = idx;
+                rb.checked = pred.visible !== false;
+                rb.addEventListener('change', () => {
+                    if (rb.checked) {
+                        this.selectedManualMaskIndex = idx;
+                        this.manualPredictions.forEach((p, i) => { p.visible = i === idx; });
+                        this.drawPredictionMaskLayer();
+                    }
+                });
+                label.appendChild(rb);
+                label.appendChild(document.createTextNode(labels[idx] || `M${idx + 1}`));
+                this.maskToggleContainer.appendChild(label);
+            });
+        }
     }
 
     // Public method to allow external modules to listen to canvas events

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -424,6 +424,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (recoverAutoMaskBtn) recoverAutoMaskBtn.addEventListener('click', handleRecoverAutoMask);
 
     async function handleRunAutoMask() {
+        if (autoMaskOverlay) utils.hideElement(autoMaskOverlay);
         const currentCanvasState = canvasManager.getCurrentCanvasInputs();
         if (!currentCanvasState.imagePresent) {
             uiManager.showGlobalStatus("Please load an image first for AutoMask.", "error"); return;
@@ -494,6 +495,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     async function handleRecoverAutoMask() {
+        if (autoMaskOverlay) utils.hideElement(autoMaskOverlay);
         const currentCanvasState = canvasManager.getCurrentCanvasInputs();
         if (!currentCanvasState.imagePresent || !currentCanvasState.filename) {
             uiManager.showGlobalStatus("No image loaded to recover automask for.", "error");

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -75,6 +75,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const autoMaskBtn = document.getElementById('auto-mask-btn');
     const cancelAutoMaskBtn = document.getElementById('cancel-auto-mask-btn');
     const recoverAutoMaskBtn = document.getElementById('recover-auto-mask-btn');
+    const openAutoMaskOverlayBtn = document.getElementById('open-auto-mask-overlay');
+    const autoMaskOverlay = document.getElementById('auto-mask-overlay');
+    const closeAutoMaskOverlayBtn = document.getElementById('close-auto-mask-overlay');
     const amgParamsElements = {
         pointsPerSideEl: document.getElementById('amg-points-per-side'),
         predIouThreshEl: document.getElementById('amg-pred-iou-thresh'),
@@ -84,6 +87,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveOverlayBtn = document.getElementById('save-masks-btn');
     const commitMasksBtn = document.getElementById('commit-masks-btn');
     const exportCocoBtn = document.getElementById('export-coco-btn');
+
+    if (openAutoMaskOverlayBtn && autoMaskOverlay) {
+        openAutoMaskOverlayBtn.addEventListener('click', () => utils.showElement(autoMaskOverlay, 'flex'));
+    }
+    if (closeAutoMaskOverlayBtn && autoMaskOverlay) {
+        closeAutoMaskOverlayBtn.addEventListener('click', () => utils.hideElement(autoMaskOverlay));
+    }
 
 
     // --- Global State Variables for main.js orchestration ---
@@ -652,9 +662,7 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('.expandable-section').forEach(section => {
             const header = section.querySelector('.expandable-header');
             if (header && uiManager && typeof uiManager.initializeExpandableSection === 'function') {
-                // Determine initial collapsed state. Auto mask section expanded by default.
-                const isInitiallyCollapsed = section.id !== 'auto-mask-section';
-                uiManager.initializeExpandableSection(header, isInitiallyCollapsed);
+                uiManager.initializeExpandableSection(header, true);
             }
         });
         

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -207,14 +207,14 @@
                         </div>
                     </div>
                     <div class="canvas-toolbar">
-                        <div class="toolbar-col left-controls">
+                        <div class="toolbar-col-1 toolbar-col left-controls">
                             <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
                             <button id="open-auto-mask-overlay">AutoMask</button>
                         </div>
-                        <div class="toolbar-col">
+                        <div class="toolbar-col-2 toolbar-col">
                             <div id="mask-toggle-container" class="mask-toggle-container"></div>
                         </div>
-                        <div class="toolbar-col">
+                        <div class="toolbar-col-3 toolbar-col">
                             <div class="opacity-controls">
                                 <div class="opacity-control">
                                     <label for="image-opacity">Image</label>
@@ -233,8 +233,8 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="toolbar-col future-tools"></div>
-                        <div class="toolbar-col help-section">
+                        <div class="toolbar-col-4 toolbar-col future-tools"></div>
+                        <div class="toolbar-col-5 toolbar-col help-section">
                             <div class="help-icon" id="help-icon" title="Show usage instructions">
                                 <span>?</span>
                                 <div class="help-tooltip">

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -135,6 +135,35 @@
                     </div>
                 </div>
 
+                <div id="auto-mask-overlay" class="modal-overlay" style="display:none;">
+                    <div class="modal-content auto-mask-modal">
+                        <button id="close-auto-mask-overlay" class="modal-close">&times;</button>
+                        <h3>Automatic Mask Generation</h3>
+                        <div class="auto-mask-controls">
+                            <div class="amg-parameters">
+                                <div class="parameter-group">
+                                    <label for="amg-points-per-side">Points per side:</label>
+                                    <input type="number" id="amg-points-per-side" value="32" min="1" max="128" title="Number of points sampled along one side of the image. Total points = value^2.">
+                                </div>
+                                <div class="parameter-group">
+                                    <label for="amg-pred-iou-thresh">Pred. IoU threshold:</label>
+                                    <input type="number" id="amg-pred-iou-thresh" value="0.88" min="0" max="1" step="0.01" title="Filters masks based on model's predicted mask quality (0-1).">
+                                </div>
+                                <div class="parameter-group">
+                                    <label for="amg-stability-score-thresh">Stability score threshold:</label>
+                                    <input type="number" id="amg-stability-score-thresh" value="0.95" min="0" max="1" step="0.01" title="Filters masks based on stability under binarization cutoff changes (0-1).">
+                                </div>
+                            </div>
+                            <div class="amg-actions">
+                                <button id="auto-mask-btn" title="Automatically generate masks for the entire image">Run AutoMask</button>
+                                <button id="cancel-auto-mask-btn" style="display: none;" title="Cancel ongoing AutoMask generation">Cancel</button>
+                                <button id="recover-auto-mask-btn" title="Try to recover previously generated AutoMask for this image from local storage">Recover Last AutoMask</button>
+                            </div>
+                            <div id="auto-mask-status" class="status-message small">Set parameters for AutoMask.</div>
+                        </div>
+                    </div>
+                </div>
+
                 <div id="image-pool-section" class="image-pool-section">
                     <div class="image-pool-controls">
                         <button id="prev-image-btn" title="Load previous image in pool">< Prev</button>
@@ -178,28 +207,34 @@
                         </div>
                     </div>
                     <div class="canvas-toolbar">
-                        <div class="toolbar-section">
+                        <div class="toolbar-col left-controls">
                             <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
+                            <button id="open-auto-mask-overlay">AutoMask</button>
                         </div>
-                        <div id="mask-toggle-container" class="mask-toggle-container"></div>
-                        <div class="opacity-controls">
-                            <div class="opacity-control">
-                                <label for="image-opacity">Image</label>
-                                <input type="range" id="image-opacity">
-                                <span id="image-opacity-value" class="opacity-value-display">100%</span>
-                            </div>
-                            <div class="opacity-control">
-                                <label for="user-input-opacity">Inputs</label>
-                                <input type="range" id="user-input-opacity">
-                                <span id="user-input-opacity-value" class="opacity-value-display">80%</span>
-                            </div>
-                            <div class="opacity-control">
-                                <label for="prediction-opacity">Masks</label>
-                                <input type="range" id="prediction-opacity">
-                                <span id="prediction-opacity-value" class="opacity-value-display">70%</span>
+                        <div class="toolbar-col">
+                            <div id="mask-toggle-container" class="mask-toggle-container"></div>
+                        </div>
+                        <div class="toolbar-col">
+                            <div class="opacity-controls">
+                                <div class="opacity-control">
+                                    <label for="image-opacity">Image</label>
+                                    <input type="range" id="image-opacity">
+                                    <span id="image-opacity-value" class="opacity-value-display">100%</span>
+                                </div>
+                                <div class="opacity-control">
+                                    <label for="user-input-opacity">Inputs</label>
+                                    <input type="range" id="user-input-opacity">
+                                    <span id="user-input-opacity-value" class="opacity-value-display">80%</span>
+                                </div>
+                                <div class="opacity-control">
+                                    <label for="prediction-opacity">Masks</label>
+                                    <input type="range" id="prediction-opacity">
+                                    <span id="prediction-opacity-value" class="opacity-value-display">70%</span>
+                                </div>
                             </div>
                         </div>
-                        <div class="toolbar-section help-section">
+                        <div class="toolbar-col future-tools"></div>
+                        <div class="toolbar-col help-section">
                             <div class="help-icon" id="help-icon" title="Show usage instructions">
                                 <span>?</span>
                                 <div class="help-tooltip">
@@ -215,37 +250,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="expandable-section auto-mask-section">
-                    <div class="expandable-header">
-                        <span>Automatic Mask Generation</span>
-                        <span class="expand-indicator">▲</span>
-                    </div>
-                    <div class="expandable-content">
-                        <div class="auto-mask-controls">
-                            <div class="amg-parameters">
-                                <!-- <h3>AMG Parameters</h3> -->
-                                <div class="parameter-group">
-                                    <label for="amg-points-per-side">Points per side:</label>
-                                    <input type="number" id="amg-points-per-side" value="32" min="1" max="128" title="Number of points sampled along one side of the image. Total points = value^2.">
-                                </div>
-                                <div class="parameter-group">
-                                    <label for="amg-pred-iou-thresh">Pred. IoU threshold:</label>
-                                    <input type="number" id="amg-pred-iou-thresh" value="0.88" min="0" max="1" step="0.01" title="Filters masks based on model's predicted mask quality (0-1).">
-                                </div>
-                                <div class="parameter-group">
-                                    <label for="amg-stability-score-thresh">Stability score threshold:</label>
-                                    <input type="number" id="amg-stability-score-thresh" value="0.95" min="0" max="1" step="0.01" title="Filters masks based on stability under binarization cutoff changes (0-1).">
-                                </div>
-                            </div>
-                            <div class="amg-actions">
-                                <button id="auto-mask-btn" title="Automatically generate masks for the entire image">Run AutoMask</button>
-                                <button id="cancel-auto-mask-btn" style="display: none;" title="Cancel ongoing AutoMask generation">Cancel</button>
-                                <button id="recover-auto-mask-btn" title="Try to recover previously generated AutoMask for this image from local storage">Recover Last AutoMask</button>
-                            </div>
-                            <div id="auto-mask-status" class="status-message small">Set parameters for AutoMask.</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- change AutoMask section into modal overlay
- split canvas toolbar into 5-column layout and add AutoMask button
- update CSS for new toolbar grid layout and overlay styling
- hook up overlay open/close events in main.js

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845488d7f348320a462a6cfd8ade7bf