### PR TITLE
Update layout and toolbar for layer view

### DIFF
--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -9,7 +9,6 @@
     padding: 10px 15px;
     background-color: #f8f9fa;
     border-radius: 6px;
-    margin-bottom: 15px;
     align-items: center;
     justify-content: center;
     border: 1px solid #e9ecef;
@@ -165,7 +164,7 @@
 .image-display-area { /* This is the direct parent of .canvas-container */
     display: flex;
     flex-direction: column; /* Stack toolbar and canvas container */
-    gap: 10px; /* Space between toolbar and canvas container */
+    gap: 1px; /* Space between toolbar and canvas container */
     flex-grow: 1; /* Allow it to take available vertical space */
     min-height: 0; /* Important for flex item to shrink properly if content overflows */
 }
@@ -182,7 +181,7 @@
     border: 1px solid #dee2e6; /* Softer border */
     border-radius: 6px;
     overflow: hidden; /* Ensure canvases don't overflow rounded corners */
-    width: 100%; /* Take full width of its parent (.canvas-column) */
+    width: 100%; /* Take full width of its parent */
 }
 
 /* Individual Canvases */
@@ -199,7 +198,7 @@
     object-fit: contain; /* Ensure image within canvas respects aspect ratio if canvas is forced to a size */
 }
 
-#image-canvas { z-index: 1; }
+#image-canvas { z-index: 1; border-radius: 0px;}
 #prediction-mask-canvas { z-index: 2; }
 #user-input-canvas {
     z-index: 3;

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -105,12 +105,11 @@ header p {
     min-width: 0;
 }
 .canvas-toolbar {
-    flex: 0 0 100%;
-    order: 2;
+    margin-top: 10px;
 }
 .layer-view-section {
-    flex: 0 0 33%;
-    max-width: 33%;
+    flex: 1 1 0;
+    max-width: none;
 }
 
 .config-section h2,

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -87,7 +87,6 @@ header p {
 /* Section Styles */
 .config-section,
 .image-section, /* This might become part of canvas-column or specific handlers */
-.results-section, /* This might be for mask lists, export buttons */
 .auto-mask-section,
 .image-pool-section {
     background: white;
@@ -98,7 +97,8 @@ header p {
 
 .image-section { display: flex; gap: 20px; align-items: flex-start; flex-wrap: wrap; }
 .image-display-area {
-    flex: 2 1 0;
+    flex: 0 0 67%;
+    max-width: 67%;
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -109,13 +109,12 @@ header p {
     order: 2;
 }
 .layer-view-section {
-    flex: 1 1 0;
+    flex: 0 0 33%;
     max-width: 33%;
 }
 
 .config-section h2,
 .image-section h2,
-.results-section h2,
 .auto-mask-section h2 { /* Combined for consistency */
     margin-top: 0; /* Remove default h2 margin if it's the first child */
     margin-bottom: 15px;
@@ -664,8 +663,8 @@ input[type="file"]#image-upload {
 /* Results & Export Controls */
 .export-controls { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 15px; }
 .export-controls button {
-    padding: 10px 20px; color: white; border: none; border-radius: 4px;
-    font-size: 14px; font-weight: 500; cursor: pointer; transition: background-color 0.2s;
+    padding: 6px 12px; color: white; border: none; border-radius: 4px;
+    font-size: 13px; font-weight: 500; cursor: pointer; transition: background-color 0.2s;
 }
 /* Individual button colors */
 #save-masks-btn { background-color: #007bff; } /* Blue for preview */
@@ -680,12 +679,12 @@ input[type="file"]#image-upload {
 /* Layer View */
 .layer-view-section { background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .layer-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
-.layer-item { display: flex; align-items: center; gap: 6px; padding: 2px 0; }
+.layer-item { display: flex; align-items: center; gap: 6px; padding: 2px 0; flex-wrap: wrap; }
 .layer-item.selected { background-color: #f0f4ff; }
 .layer-vis-toggle { border: none; background: none; cursor: pointer; }
 .layer-color-swatch { width: 16px; height: 16px; border-radius: 3px; border: 1px solid #ccc; }
-.layer-name-input { flex: 1 1 auto; padding: 2px 4px; font-size: 13px; }
-.layer-class-input { flex: 0 0 70px; padding: 2px 4px; font-size: 11px; }
+.layer-name-input { flex: 1 1 45%; padding: 2px 4px; font-size: 13px; }
+.layer-class-input { flex: 1 1 25%; min-width: 60px; padding: 2px 4px; font-size: 11px; }
 .layer-status-tag { font-size: 11px; padding: 2px 4px; border-radius: 4px; background-color: #eee; text-transform: capitalize; }
 .layer-status-tag.prediction { background-color: #007bff; color: #fff; }
 .layer-status-tag.edited { background-color: #ffc107; color: #333; }

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -863,12 +863,14 @@ input[type="file"]#image-upload {
 }
 #status-console.latest-line {
     overflow-y: hidden;
+    background: #222; /* 100% opacity for latest-line mode */
 }
 #status-console.latest-line .status-entry:not(:last-child) {
     display: none;
 }
 #status-console.expanded {
     height: 25vh;
+    background: #222E; /* Slightly transparent for expanded mode */
 }
 #status-console.collapsed {
     display: none;

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -97,7 +97,7 @@ header p {
 
 .image-section {
     display: grid;
-    grid-template-columns: 67% 1fr;
+    grid-template-columns: 75% 1fr;
     gap: 20px;
     align-items: flex-start;
 }
@@ -112,7 +112,10 @@ header p {
     margin-top: 10px;
 }
 .layer-view-section {
-    width: 100%;
+    width: auto;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .config-section h2,
@@ -543,7 +546,7 @@ ul.image-sources-list li span { flex-grow: 1; }
 .image-status-badge.in_progress { background-color: #ffc107; color: #333; }
 .image-status-badge.ready_for_review { background-color: #17a2b8; color: #fff; }
 .image-status-badge.approved { background-color: #28a745; }
-.image-status-badge.rejected { background-color: #dc3545; }
+.image-status-badge.rejected { background-color: #dc3545; color: #fff; }
 .image-status-badge.skip { background-color: #6c757d; }
 .image-status-badge.unknown { background-color: #adb5bd; }
 
@@ -685,8 +688,18 @@ input[type="file"]#image-upload {
 .layer-item.selected { background-color: #f0f4ff; }
 .layer-vis-toggle { border: none; background: none; cursor: pointer; }
 .layer-color-swatch { width: 16px; height: 16px; border-radius: 3px; border: 1px solid #ccc; }
-.layer-name-input { flex: 1 1 45%; padding: 2px 4px; font-size: 13px; }
-.layer-class-input { flex: 1 1 25%; min-width: 60px; padding: 2px 4px; font-size: 11px; }
+.layer-name-input { 
+    flex: 1 1 25px;
+    min-width: 25px; 
+    padding: 2px 4px; 
+    font-size: 13px; 
+}
+.layer-class-input { 
+    flex: 2 1 25px;
+    min-width: 30px; 
+    padding: 2px 4px; 
+    font-size: 11px; 
+}
 .layer-status-tag { font-size: 11px; padding: 2px 4px; border-radius: 4px; background-color: #eee; text-transform: capitalize; }
 .layer-status-tag.prediction { background-color: #007bff; color: #fff; }
 .layer-status-tag.edited { background-color: #ffc107; color: #333; }
@@ -728,6 +741,10 @@ input[type="file"]#image-upload {
 @media (max-width: 900px) {
     .image-section {
         grid-template-columns: 1fr;
+        gap: 15px;
+    }
+    .layer-view-section {
+        width: 100%;
     }
 }
 @media (max-width: 480px) {

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -95,10 +95,14 @@ header p {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.image-section { display: flex; gap: 20px; align-items: flex-start; flex-wrap: wrap; }
+.image-section {
+    display: grid;
+    grid-template-columns: 67% 1fr;
+    gap: 20px;
+    align-items: flex-start;
+}
 .image-display-area {
-    flex: 0 0 67%;
-    max-width: 67%;
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -108,8 +112,7 @@ header p {
     margin-top: 10px;
 }
 .layer-view-section {
-    flex: 1 1 0;
-    max-width: none;
+    width: 100%;
 }
 
 .config-section h2,
@@ -721,6 +724,11 @@ input[type="file"]#image-upload {
     .amg-actions button { width: 100%; }
     #clear-inputs-btn { width: 100%; margin-top: 10px; }
     .export-controls button { width: 100%; }
+}
+@media (max-width: 900px) {
+    .image-section {
+        grid-template-columns: 1fr;
+    }
 }
 @media (max-width: 480px) {
     .custom-input-group input[type="text"],

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -15,14 +15,14 @@ body {
     flex-direction: column; /* Stack header and main content */
     align-items: center; /* Center .container horizontally */
     min-height: 100vh; /* Ensure body takes full viewport height */
-    padding: 10px;
+    padding: 0px; /* Make .container control padding */
 }
 
 .container {
-    width: 95%;
-    max-width: 95%;
+    width: 100%;
+    max-width: 100%;
     /* margin: 0 auto; /* Centering handled by body flexbox */
-    padding: 20px;
+    padding: 5px 20px 35px 20px;
     display: flex; /* Use flexbox for layout within container */
     flex-direction: column; /* Stack sections vertically */
     gap: 20px;
@@ -69,28 +69,19 @@ header p {
 }
 
 .controls-column {
-    flex: 0 0 380px; /* Fixed width for controls column */
+    flex: 0 0 380px; 
     display: flex;
     flex-direction: column;
     gap: 20px;
 }
-
-.canvas-column {
-    flex: 1 1 auto; /* Canvas column takes remaining space */
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-    min-width: 0; /* Important for flex item to shrink properly */
-}
-
 
 /* Section Styles */
 .config-section,
-.image-section, /* This might become part of canvas-column or specific handlers */
+.image-section,
 .auto-mask-section,
 .image-pool-section {
     background: white;
-    padding: 20px;
+    padding: 8px;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
@@ -98,7 +89,7 @@ header p {
 .image-section {
     display: grid;
     grid-template-columns: 75% 1fr;
-    gap: 20px;
+    gap: 5px;
     align-items: flex-start;
 }
 .image-display-area {
@@ -107,9 +98,6 @@ header p {
     flex-direction: column;
     gap: 10px;
     min-width: 0;
-}
-.canvas-toolbar {
-    margin-top: 10px;
 }
 .layer-view-section {
     width: auto;

--- a/app/frontend/static/js/layerViewController.js
+++ b/app/frontend/static/js/layerViewController.js
@@ -14,13 +14,15 @@ class LayerViewController {
     }
 
     setLayers(layers) {
-        this.layers = Array.isArray(layers) ? layers : [];
+        // Clone incoming array so external mutations (e.g., from ActiveImageState)
+        // do not directly modify our internal list and cause double updates.
+        this.layers = Array.isArray(layers) ? layers.map(l => ({ ...l })) : [];
         this.render();
     }
 
     addLayers(newLayers) {
-        if (Array.isArray(newLayers)) {
-            this.layers.push(...newLayers);
+        if (Array.isArray(newLayers) && newLayers.length > 0) {
+            this.layers.push(...newLayers.map(l => ({ ...l })));
             this.render();
         }
     }

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -239,7 +239,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (existingMasks && existingMasks.length > 0) {
             activeImageState.layers = existingMasks.map((m, idx) => ({
                 layerId: m.layer_id || `layer_${idx}`,
-                name: m.name || `Layer ${idx + 1}`,
+                name: m.name || `Mask ${idx + 1}`,
                 classLabel: m.class_label || '',
                 status: m.layer_type || 'prediction',
                 visible: true,
@@ -632,7 +632,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const masksToCommit = selected.map((mask, idx) => ({
                 segmentation: mask.segmentation || mask,
                 source_layer_ids: [],
-                name: `layer_${activeImageState.layers.length + idx + 1}`
+                name: `Mask ${activeImageState.layers.length + idx + 1}`
             }));
 
             const activeProjectId = stateManager.getActiveProjectId();

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -614,7 +614,8 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    if (commitMasksBtn) {
+    if (commitMasksBtn && !commitMasksBtn.dataset.listenerAttached) {
+        commitMasksBtn.dataset.listenerAttached = 'true';
         commitMasksBtn.addEventListener('click', async () => {
             if (!activeImageState) return;
             const predictions = canvasManager.manualPredictions && canvasManager.manualPredictions.length > 0

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -212,6 +212,7 @@
                         <div class="toolbar-col-1 toolbar-col left-controls">
                             <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
                             <button id="open-auto-mask-overlay">AutoMask</button>
+                            <button id="commit-masks-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
                         </div>
                         <div class="toolbar-col-2 toolbar-col">
                             <div id="mask-toggle-container" class="mask-toggle-container"></div>
@@ -254,20 +255,15 @@
                             </div>
                         </div>
                     </div>
-                </div>
-                <div id="layer-view-section" class="layer-view-section">
-                    <h2>Layer View <button id="add-empty-layer-btn" title="Create empty layer">+</button></h2>
-                    <div id="layer-view-container">
-                        <p><em>No layers yet. Use "Add to Layers".</em></p>
-                    </div>
-                </div>
-                <div class="results-section">
-                    <h2>Final Masks & Export</h2>
-                    <div class="export-controls">
-                        <button id="save-masks-btn" title="Download a PNG preview of the current canvas with overlays">Save Overlay Preview</button>
-                         <button id="commit-masks-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
-                         <button id="export-coco-btn" title="Export selected/all project data in COCO format">Export COCO JSON</button>
-                        <p style="margin-top: 10px; font-size: 14px; color: #666;"><i>More export options and mask list will be added.</i></p>
+                    <div id="layer-view-section" class="layer-view-section">
+                        <h2>Layer View <button id="add-empty-layer-btn" title="Create empty layer">+</button></h2>
+                        <div id="layer-view-container">
+                            <p><em>No layers yet. Use "Add to Layers".</em></p>
+                        </div>
+                        <div class="export-controls">
+                            <button id="save-masks-btn" title="Download a PNG preview of the current canvas with overlays">Save Overlay Preview</button>
+                            <button id="export-coco-btn" title="Export selected/all project data in COCO format">Export COCO JSON</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -254,15 +254,15 @@
                             </div>
                         </div>
                     </div>
-                    <div id="layer-view-section" class="layer-view-section">
-                        <h2>Layer View <button id="add-empty-layer-btn" title="Create empty layer">+</button></h2>
-                        <div id="layer-view-container">
-                            <p><em>No layers yet. Use "Add to Layers".</em></p>
-                        </div>
-                        <div class="export-controls">
-                            <button id="save-masks-btn" title="Download a PNG preview of the current canvas with overlays">Save Overlay Preview</button>
-                            <button id="export-coco-btn" title="Export selected/all project data in COCO format">Export COCO JSON</button>
-                        </div>
+                </div>
+                <div id="layer-view-section" class="layer-view-section">
+                    <button id="add-empty-layer-btn" title="Create empty layer">+</button>
+                    <div id="layer-view-container">
+                        <p><em>No layers yet. Use "Add to Layers".</em></p>
+                    </div>
+                    <div class="export-controls">
+                        <button id="save-masks-btn" title="Download a PNG preview of the current canvas with overlays">Save Overlay Preview</button>
+                        <button id="export-coco-btn" title="Export selected/all project data in COCO format">Export COCO JSON</button>
                     </div>
                 </div>
             </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -207,13 +207,12 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="canvas-toolbar">
-                        <div class="toolbar-col-1 toolbar-col left-controls">
-                            <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
-                            <button id="open-auto-mask-overlay">AutoMask</button>
-                            <button id="commit-masks-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
-                        </div>
+                        <div class="canvas-toolbar">
+                            <div class="toolbar-col-1 toolbar-col left-controls">
+                                <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
+                                <button id="open-auto-mask-overlay">AutoMask</button>
+                                <button id="commit-masks-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
+                            </div>
                         <div class="toolbar-col-2 toolbar-col">
                             <div id="mask-toggle-container" class="mask-toggle-container"></div>
                         </div>


### PR DESCRIPTION
## Summary
- place layer-view-section inside image-section beside the canvas
- put Add to Layers button in the canvas toolbar
- move export buttons below the layer list and compact their style
- adjust layout widths and responsive layer row styling
- drop obsolete results section styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847614f79948320ab3a85712108b2b0