### PR TITLE
docs: add annotation workflow progress tracker

### DIFF
--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -1,0 +1,70 @@
+# Annotation Workflow Implementation Progress
+
+This document tracks the progress of implementing the features described in
+`docs/annotation_workflow_specification.md`.
+It will be updated as new sprints add functionality.
+
+## Completed Features
+- **Main Layout**: The canvas and Layer View display side by side within the
+  `image-section`, matching the specification.
+- **Layer View Panel**: Initial controller supports layer listing with
+  visibility toggle, color swatch, editable name and class label fields, status
+  tag display, selection highlighting and deletion.
+- **Add to Layers Workflow**: Predictions can be added to the Layer View instead
+  of committing a single final mask. The *Add Empty Layer* button is also
+  available.
+- **Image Pool Filter**: Filter dropdown includes new statuses
+  (`unprocessed`, `in_progress`, `ready_for_review`, `approved`, `rejected`,
+  `skip`), and CSS badges reflect these states.
+- **Export Logic**: `export_logic.py` accepts filter lists for image and layer
+  statuses, builds dynamic COCO categories from layer labels and uses
+  `pycocotools` for RLE conversion.
+- **Database Helpers**: Added `get_image_hashes_by_statuses` and
+  `get_layers_by_image_and_statuses` for more efficient export queries.
+
+## Partially Implemented / In Progress
+- **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded
+  layers, but it lacks the complete structure (creation/edit objects) and direct
+  synchronization with the backend as described.
+- **Image Status Handling**: Frontend shows new statuses, but the database schema
+  and backend still use the previous status values
+  (`in_progress_auto`, `in_progress_manual`, `completed`).
+- **Layer Data Schema**: Layers are stored with the old `layer_type` field and do
+  not yet include `class_label`, `status` (prediction/edited/approved),
+  `display_color`, or `source_metadata` columns.
+- **Edit Mode Tools**: Selecting a layer only displays its mask; brush/eraser,
+  lasso, and other edit tools have not been implemented.
+- **Review Mode Interface**: No dedicated review workflow exists yet.
+
+## Planned Tasks (Priority Order)
+1. **Database and API Refactor**
+   - Migrate the `Images` and `Mask_Layers` tables to the new schema with image
+     statuses (`unprocessed`, `in_progress`, `ready_for_review`, `approved`,
+     `rejected`, `skip`) and per-layer fields (`class_label`, `status`,
+     `display_color`, `source_metadata`, `updated_at`).
+   - Adjust CRUD helpers and update existing endpoints to read/write the new
+     schema.
+   - Introduce `/api/project/<id>/image/<hash>/state` `GET`/`PUT` endpoints for
+     full `ActiveImageState` synchronization.
+2. **Frontend State Management**
+   - Implement the full `ActiveImageState` object with `creation` and `edit`
+     subobjects and automatic saving/loading through the new API endpoints.
+   - Update `layerViewController` and `canvasController` to operate on this state.
+3. **Edit Mode Implementation**
+   - Add an `editModeController` with brush/eraser, lasso, and action buttons
+     (grow, shrink, smooth, invert, undo/redo, save, cancel).
+   - Ensure selecting a layer activates edit mode and saving edits updates the
+     layer status to `edited`.
+4. **Review Workflow**
+   - Provide UI to mark images `ready_for_review` and a streamlined review view
+     for approving or rejecting images.
+   - Update export and filtering logic to handle the full status lifecycle.
+5. **Incremental Enhancements**
+   - Persist `display_color` and label information when adding layers.
+   - Add update-status dropdown in the annotation view.
+   - Improve error handling and autosave of `ActiveImageState` to prevent data
+     loss.
+
+The above order follows the staged rollout suggested in the specification:
+getting the schema and state management in place will make subsequent editing and
+review features easier to build while keeping the application functional.


### PR DESCRIPTION
## Summary
- add `annotation_workflow_progress.md` to track progress toward the workflow spec

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848542bdf3483208cde5284f96d88a6