### PR TITLE
Handle missing sam2 or torch gracefully

### DIFF
--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -189,6 +189,9 @@ def load_sam_model_for_project(project_id: str, sam_inference: SAMInference,
                                config_path_override: Optional[str] = None,
                                apply_postprocessing: bool = True,
                                progress_callback=None) -> Dict[str, Any]:
+    if not sam_inference.sam_available:
+        return {"success": False, "error": "SAM backend unavailable"}
+
     success = sam_inference.load_model(
         model_size_key=model_size_key,
         model_path_override=model_path_override,
@@ -208,6 +211,9 @@ def load_sam_model_for_project(project_id: str, sam_inference: SAMInference,
 
 def get_current_model_for_project(project_id: str, sam_inference: SAMInference) -> Dict[str, Any]:
     """Ensure the SAM model associated with a project is loaded and return info."""
+    if not sam_inference.sam_available:
+        return sam_inference.get_model_info()
+
     model_key = db_manager.get_project_setting(project_id, "current_sam_model_key")
     model_path = db_manager.get_project_setting(project_id, "current_sam_model_path")
     config_path = db_manager.get_project_setting(project_id, "current_sam_config_path")
@@ -394,6 +400,8 @@ def set_active_image_for_project(project_id: str, image_hash: str, sam_inference
 
 # --- Annotation ---
 def process_automask_request(project_id: str, image_hash: str, sam_inference: SAMInference, amg_params: Dict) -> Dict[str, Any]:
+    if not sam_inference.sam_available:
+        return {"success": False, "error": "SAM backend unavailable"}
     if not sam_inference.model:
         return {"success": False, "error": "Model not loaded."}
     if sam_inference.image_hash != image_hash: # Ensure correct image is active
@@ -465,6 +473,8 @@ def process_automask_request(project_id: str, image_hash: str, sam_inference: SA
 
 def process_interactive_predict_request(project_id: str, image_hash: str, sam_inference: SAMInference,
                                         prompts: Dict, predict_params: Dict) -> Dict[str, Any]:
+    if not sam_inference.sam_available:
+        return {"success": False, "error": "SAM backend unavailable"}
     if not sam_inference.model:
         return {"success": False, "error": "Model not loaded."}
     if sam_inference.image_hash != image_hash:

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -119,7 +119,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     applyPostprocessing: data.model_info.apply_postprocessing
                 });
 
-                if (data.model_info.loaded) {
+                if (!data.model_info.available) {
+                    uiManager.showGlobalStatus('Backend inference unavailable. Prediction features disabled.', 'error', 5000);
+                } else if (data.model_info.loaded) {
                     utils.dispatchCustomEvent('model-load-success', {
                         model_info: data.model_info,
                         message: 'Model ready.'

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -119,6 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     applyPostprocessing: data.model_info.apply_postprocessing
                 });
 
+                window.samAvailable = data.model_info.available;
                 if (!data.model_info.available) {
                     uiManager.showGlobalStatus('Backend inference unavailable. Prediction features disabled.', 'error', 5000);
                 } else if (data.model_info.loaded) {

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -120,6 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
 
                 window.samAvailable = data.model_info.available;
+                document.dispatchEvent(new CustomEvent('sam-availability-updated', { detail: { available: window.samAvailable } }));
                 if (!data.model_info.available) {
                     uiManager.showGlobalStatus('Backend inference unavailable. Prediction features disabled.', 'error', 5000);
                 } else if (data.model_info.loaded) {

--- a/app/frontend/static/js/modelHandler.js
+++ b/app/frontend/static/js/modelHandler.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const loadModelBtn = document.getElementById('load-model-btn');
     const applyPostprocessingCb = document.getElementById('apply-postprocessing-cb');
     const modelStatusInline = document.getElementById('model-status-inline');
+    const backendStatusEl = document.getElementById('model-backend-status');
     const customModelInputs = document.getElementById('custom-model-inputs');
     const customModelPathInput = document.getElementById('custom-model-path'); // Renamed for clarity
     const customConfigPathInput = document.getElementById('custom-config-path'); // Renamed for clarity
@@ -17,7 +18,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const Utils = window.Utils || { dispatchCustomEvent: (name, detail) => document.dispatchEvent(new CustomEvent(name, { detail })) };
 
     function showOverlay() {
-        if (modelOverlay) Utils.showElement(modelOverlay, 'flex');
+        if (modelOverlay) {
+            Utils.showElement(modelOverlay, 'flex');
+            if (backendStatusEl) {
+                if (window.samAvailable === false) {
+                    backendStatusEl.textContent = 'Backend inference unavailable on the server. Model loading is disabled.';
+                    backendStatusEl.style.display = 'block';
+                    loadModelBtn.disabled = true;
+                } else {
+                    backendStatusEl.textContent = '';
+                    backendStatusEl.style.display = 'none';
+                    loadModelBtn.disabled = false;
+                }
+            }
+        }
     }
 
     function hideOverlay() {
@@ -38,6 +52,22 @@ document.addEventListener('DOMContentLoaded', () => {
                 const response = await fetch('/api/models/available'); // Standardized endpoint
                 if (!response.ok) throw new Error(`HTTP error ${response.status}`);
                 data = await response.json();
+            }
+
+            if (typeof data.sam_available !== 'undefined') {
+                window.samAvailable = data.sam_available;
+            }
+
+            if (backendStatusEl) {
+                if (window.samAvailable === false) {
+                    backendStatusEl.textContent = 'Backend inference unavailable on the server. Model loading is disabled.';
+                    backendStatusEl.style.display = 'block';
+                    loadModelBtn.disabled = true;
+                } else {
+                    backendStatusEl.textContent = '';
+                    backendStatusEl.style.display = 'none';
+                    loadModelBtn.disabled = false;
+                }
             }
 
             if (data.success) {

--- a/app/frontend/static/js/projectHandler.js
+++ b/app/frontend/static/js/projectHandler.js
@@ -168,8 +168,11 @@ class ProjectHandler {
     }
 
     _checkAndShowModelOverlay() {
-        // Auto-show overlay only when backend inference is unavailable
-        if (window.samAvailable === false) {
+        // Only show overlay if backend inference is available and model not loaded
+        const modelStatusInline = document.getElementById('model-status-inline');
+        const isModelLoaded = modelStatusInline && modelStatusInline.classList.contains('loaded');
+
+        if (!isModelLoaded && window.samAvailable !== false) {
             const modelOverlay = document.getElementById('model-management-overlay');
             if (modelOverlay && this.Utils.showElement) {
                 this.Utils.showElement(modelOverlay, 'flex');

--- a/app/frontend/static/js/projectHandler.js
+++ b/app/frontend/static/js/projectHandler.js
@@ -168,12 +168,8 @@ class ProjectHandler {
     }
 
     _checkAndShowModelOverlay() {
-        // Check if model is already loaded by looking at the model status
-        const modelStatusInline = document.getElementById('model-status-inline');
-        const isModelLoaded = modelStatusInline && modelStatusInline.classList.contains('loaded');
-        
-        if (!isModelLoaded) {
-            // Show model overlay
+        // Auto-show overlay only when backend inference is unavailable
+        if (window.samAvailable === false) {
             const modelOverlay = document.getElementById('model-management-overlay');
             if (modelOverlay && this.Utils.showElement) {
                 this.Utils.showElement(modelOverlay, 'flex');

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -65,6 +65,7 @@
                     <div class="modal-content model-modal">
                         <button id="close-model-overlay" class="modal-close">&times;</button>
                         <h3>Model Management</h3>
+                        <div id="model-backend-status" class="status-message error small" style="display:none; margin-top:4px;"></div>
                         <br>
                         <div class="model-controls">
                             <div class="model-selection">

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ opencv-python
 fastapi
 uvicorn
 python-multipart
+werkzeug
 requests
 pycocotools>=2.0.8
 haikunator


### PR DESCRIPTION
## Summary
- let `sam_backend` handle missing `sam2` or `torch` modules gracefully
- propagate backend availability status through project logic and server
- expose `sam_available` info to the frontend and disable prediction when unavailable
- notify the user via UI if inference isn't available

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d20f68c2083209b17528bfdcabeb3