### PR TITLE
Implement new image statuses

### DIFF
--- a/app/backend/db_manager.py
+++ b/app/backend/db_manager.py
@@ -481,6 +481,15 @@ def get_mask_layers_for_image(project_id: str, image_hash: str, layer_type: Opti
     conn.close()
     return layers
 
+def count_mask_layers_for_image(project_id: str, image_hash: str) -> int:
+    """Returns the number of mask layers for the given image."""
+    conn = get_db_connection(project_id)
+    cursor = conn.cursor()
+    cursor.execute("SELECT COUNT(*) FROM Mask_Layers WHERE image_hash_ref = ?", (image_hash,))
+    count = cursor.fetchone()[0]
+    conn.close()
+    return count
+
 def delete_mask_layer(project_id: str, layer_id: str) -> None:
     conn = get_db_connection(project_id)
     cursor = conn.cursor()

--- a/app/backend/db_manager.py
+++ b/app/backend/db_manager.py
@@ -92,7 +92,7 @@ def init_project_db(project_id: str, project_name: str) -> None:
         path_in_source TEXT, -- Relative path or identifier within the source
         width INTEGER,
         height INTEGER,
-        status TEXT DEFAULT 'unprocessed', -- e.g., "unprocessed", "in_progress_auto", "in_progress_manual", "completed"
+        status TEXT DEFAULT 'unprocessed', -- e.g., "unprocessed", "in_progress", "ready_for_review", "approved", "rejected", "skip"
         added_to_pool_at TEXT NOT NULL,
         last_processed_at TEXT,
         notes TEXT,

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -363,8 +363,8 @@ def sync_image_status_with_layers(project_id: str, image_hash: str) -> str:
     if current == "skip":
         return current
 
-    layers = db_manager.get_mask_layers_for_image(project_id, image_hash)
-    if not layers:
+    layer_count = db_manager.count_mask_layers_for_image(project_id, image_hash)
+    if layer_count == 0:
         if current != "unprocessed":
             db_manager.update_image_status(project_id, image_hash, "unprocessed")
             current = "unprocessed"

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -331,16 +331,20 @@ def add_image_source_folder(project_id: str, folder_path: str) -> Dict[str, Any]
 # TODO: Implement add_image_source_url and add_image_source_azure as per spec
 # These would involve fetching images, hashing, and adding to pool.
 
-def ensure_minimum_image_status(project_id: str, image_hash: str, min_status: str) -> None:
-    """Ensure the image's status is at least ``min_status`` in the workflow order."""
+def ensure_minimum_image_status(project_id: str, image_hash: str, min_status: str) -> str:
+    """Ensure the image's status is at least ``min_status`` in the workflow order.
+    Returns the resulting status."""
     order = ["unprocessed", "in_progress", "ready_for_review", "approved", "rejected", "skip"]
     info = db_manager.get_image_by_hash(project_id, image_hash)
     current = info.get("status") if info else None
     try:
         if current is None or order.index(min_status) > order.index(current):
             db_manager.update_image_status(project_id, image_hash, min_status)
+            current = min_status
     except ValueError:
         db_manager.update_image_status(project_id, image_hash, min_status)
+        current = min_status
+    return current or min_status
 
 def set_active_image_for_project(project_id: str, image_hash: str, sam_inference: SAMInference) -> Dict[str, Any]:
     image_info_db = db_manager.get_image_by_hash(project_id, image_hash)
@@ -477,9 +481,9 @@ def process_automask_request(project_id: str, image_hash: str, sam_inference: SA
         mask_data_rle=json.dumps(processed_mask_data_for_db), # List of RLEs and their metadata
         metadata={"source_amg_params": amg_params, "count": len(auto_masks_anns)}
     )
-    ensure_minimum_image_status(project_id, image_hash, "in_progress")
+    new_status = ensure_minimum_image_status(project_id, image_hash, "in_progress")
 
-    return {"success": True, "masks_data": processed_mask_data_for_client, "layer_id": layer_id}
+    return {"success": True, "masks_data": processed_mask_data_for_client, "layer_id": layer_id, "image_status": new_status}
 
 
 def process_interactive_predict_request(project_id: str, image_hash: str, sam_inference: SAMInference,
@@ -544,7 +548,7 @@ def process_interactive_predict_request(project_id: str, image_hash: str, sam_in
 
 
     # Update image status but do not store these transient masks in the DB.
-    ensure_minimum_image_status(project_id, image_hash, "in_progress")
+    new_status = ensure_minimum_image_status(project_id, image_hash, "in_progress")
 
     # Client expects 'masks_data' as list of 2D binary arrays, and 'scores'
     return {
@@ -554,6 +558,7 @@ def process_interactive_predict_request(project_id: str, image_hash: str, sam_in
         "layer_id": layer_id,
         "num_boxes": num_boxes,
         "multimask_output": multimask_flag,
+        "image_status": new_status,
     }
 
 
@@ -594,5 +599,17 @@ def commit_final_masks(project_id: str, image_hash: str, final_masks_data: List[
         # db_manager.update_image_notes(project_id, image_hash, new_notes) # Add this to db_manager
 
     # When masks are committed, ensure the image status is at least 'in_progress'.
-    ensure_minimum_image_status(project_id, image_hash, "in_progress")
-    return {"success": True, "message": "Masks committed.", "final_layer_ids": committed_layer_ids}
+    new_status = ensure_minimum_image_status(project_id, image_hash, "in_progress")
+    return {"success": True, "message": "Masks committed.", "final_layer_ids": committed_layer_ids, "image_status": new_status}
+
+
+def delete_mask_layer_and_update_status(project_id: str, image_hash: str, layer_id: str) -> Dict[str, Any]:
+    """Delete a mask layer and update image status if no layers remain."""
+    db_manager.delete_mask_layer(project_id, layer_id)
+    remaining = db_manager.get_mask_layers_for_image(project_id, image_hash)
+    if not remaining:
+        db_manager.update_image_status(project_id, image_hash, "unprocessed")
+        new_status = "unprocessed"
+    else:
+        new_status = ensure_minimum_image_status(project_id, image_hash, "in_progress")
+    return {"success": True, "message": "Layer deleted.", "image_status": new_status}

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -466,7 +466,7 @@ def process_automask_request(project_id: str, image_hash: str, sam_inference: SA
         mask_data_rle=json.dumps(processed_mask_data_for_db), # List of RLEs and their metadata
         metadata={"source_amg_params": amg_params, "count": len(auto_masks_anns)}
     )
-    db_manager.update_image_status(project_id, image_hash, "in_progress_auto")
+    db_manager.update_image_status(project_id, image_hash, "in_progress")
 
     return {"success": True, "masks_data": processed_mask_data_for_client, "layer_id": layer_id}
 
@@ -533,7 +533,7 @@ def process_interactive_predict_request(project_id: str, image_hash: str, sam_in
 
 
     # Update image status but do not store these transient masks in the DB.
-    db_manager.update_image_status(project_id, image_hash, "in_progress_manual")
+    db_manager.update_image_status(project_id, image_hash, "in_progress")
 
     # Client expects 'masks_data' as list of 2D binary arrays, and 'scores'
     return {
@@ -582,5 +582,5 @@ def commit_final_masks(project_id: str, image_hash: str, final_masks_data: List[
         new_notes = f"{existing_notes}\n[{datetime.utcnow().isoformat()}] {notes}".strip()
         # db_manager.update_image_notes(project_id, image_hash, new_notes) # Add this to db_manager
 
-    db_manager.update_image_status(project_id, image_hash, "completed") # Or configurable status
+    db_manager.update_image_status(project_id, image_hash, "approved")
     return {"success": True, "message": "Masks committed.", "final_layer_ids": committed_layer_ids}

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -448,6 +448,14 @@ async def api_get_image_masks(project_id: str, image_hash: str, layer_type: Opti
     return {'success': True, 'masks': mask_layers}
 
 
+@app.delete('/api/project/{project_id}/images/{image_hash}/layers/{layer_id}')
+async def api_delete_mask_layer(project_id: str, image_hash: str, layer_id: str):
+    if project_id != get_active_project_id():
+        raise HTTPException(status_code=403, detail='Operation only allowed on the active project')
+    result = await run_in_threadpool(project_logic.delete_mask_layer_and_update_status, project_id, image_hash, layer_id)
+    return result
+
+
 @app.post('/api/project/{project_id}/export')
 async def api_export_data(project_id: str, payload: dict):
     if project_id != get_active_project_id():

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -337,8 +337,13 @@ async def api_update_image_status(project_id: str, image_hash: str, payload: dic
     status = payload.get('status')
     if not status:
         raise HTTPException(status_code=400, detail='New status is required')
+
+    if status == 'sync_with_layers':
+        new_status = await run_in_threadpool(project_logic.sync_image_status_with_layers, project_id, image_hash)
+        return {'success': True, 'status': new_status}
+
     await run_in_threadpool(db_manager.update_image_status, project_id, image_hash, status)
-    return {'success': True, 'message': 'Image status updated.'}
+    return {'success': True, 'status': status}
 
 
 

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -667,6 +667,22 @@ input[type="file"]#image-upload {
 
 .export-controls button:disabled { background-color: #adb5bd; cursor: not-allowed; }
 
+/* Image Status Controls */
+.image-status-controls { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
+.review-mode-controls { display: flex; gap: 10px; margin-top: 10px; }
+.review-mode-controls button {
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+}
+.review-mode-controls #review-skip-btn { background-color: #6c757d; color: #fff; }
+.review-mode-controls #review-approve-btn { background-color: #28a745; color: #fff; }
+.review-mode-controls #review-reject-btn { background-color: #dc3545; color: #fff; }
+
+
 /* Layer View */
 .layer-view-section { background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .layer-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -275,6 +275,58 @@ header p {
 .checkbox-label { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 14px; }
 .checkbox-label input[type="checkbox"] { transform: scale(1.1); margin-right: 5px; }
 
+/* Toggle Switch Styles */
+.switch-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 14px;
+}
+.switch-control input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.switch-control .switch-slider {
+    position: relative;
+    width: 34px;
+    height: 18px;
+    background-color: #ccc;
+    border-radius: 34px;
+    transition: background-color 0.2s;
+}
+.switch-control .switch-slider::before {
+    content: '';
+    position: absolute;
+    height: 14px;
+    width: 14px;
+    left: 2px;
+    top: 2px;
+    background-color: white;
+    border-radius: 50%;
+    transition: transform 0.2s;
+}
+.switch-control input:checked + .switch-slider {
+    background-color: #28a745;
+}
+.switch-control input:checked + .switch-slider::before {
+    transform: translateX(16px);
+}
+.switch-control input:disabled + .switch-slider {
+    background-color: #e9ecef;
+    cursor: not-allowed;
+}
+.switch-control input:disabled + .switch-slider::before {
+    background-color: #f8f9fa;
+}
+.switch-control .switch-label-text {
+    user-select: none;
+}
+.switch-control input:disabled ~ .switch-label-text {
+    color: #868e96;
+}
+
 
 /* Project Controls (inside #project-management-expandable) */
 .project-controls {

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -270,6 +270,11 @@ class APIClient {
     }
 }
 
+// Expose the class for direct access in case other modules load before main.js
+if (typeof window !== 'undefined') {
+    window.APIClient = APIClient;
+}
+
 // Instantiate when DOM is ready and make it globally accessible
 // This is typically handled by main.js, but for direct use:
 // document.addEventListener('DOMContentLoaded', () => {

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -183,9 +183,6 @@ class APIClient {
     async updateImageStatus(projectId, imageHash, status) {
         return this._request(`/project/${projectId}/images/${imageHash}/status`, 'PUT', { status });
     }
-    async syncImageStatusWithLayers(projectId, imageHash) {
-        return this._request(`/project/${projectId}/images/${imageHash}/status`, 'PUT', { status: 'sync_with_layers' });
-    }
     getImageThumbnailUrl(projectId, imageHash) { // Returns URL string
         return `${this.baseUrl}/image/thumbnail/${projectId}/${imageHash}`; // Corrected, assuming endpoint exists
     }

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -183,6 +183,9 @@ class APIClient {
     async updateImageStatus(projectId, imageHash, status) {
         return this._request(`/project/${projectId}/images/${imageHash}/status`, 'PUT', { status });
     }
+    async syncImageStatusWithLayers(projectId, imageHash) {
+        return this._request(`/project/${projectId}/images/${imageHash}/status`, 'PUT', { status: 'sync_with_layers' });
+    }
     getImageThumbnailUrl(projectId, imageHash) { // Returns URL string
         return `${this.baseUrl}/image/thumbnail/${projectId}/${imageHash}`; // Corrected, assuming endpoint exists
     }

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -215,6 +215,9 @@ class APIClient {
         if (layerType) query = `?layer_type=${layerType}`;
         return this._request(`/project/${projectId}/images/${imageHash}/masks${query}`);
     }
+    async deleteMaskLayer(projectId, imageHash, layerId) {
+        return this._request(`/project/${projectId}/images/${imageHash}/layers/${layerId}`, 'DELETE');
+    }
 
     // --- Export Endpoints ---
     async requestExport(projectId, payload) {

--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -28,10 +28,11 @@
  *   - Calls to apiClient.js: `listImages`, `setActiveImage`, `updateImageStatus`.
  *   - Updates UI: Populates image gallery, updates navigation button states.
  *   - Custom DOM Events:
- *     - `active-image-set`: Detail: { imageHash, filename, width, height, imageDataBase64, existingMasks }
+ *     - `active-image-set`: Detail: { imageHash, filename, width, height, imageDataBase64, existingMasks, status }
+ *     - `active-image-cleared`: Detail: {}
  *     - `image-pool-updated`: Detail: { images: Array, pagination: object }
  *     - `image-load-request`: Detail: { imageHash: string } // Alternative to direct setActiveImage
- */
+*/
 class ImagePoolHandler {
     constructor(apiClient, stateManager, uiManager, Utils) {
         this.apiClient = apiClient;
@@ -266,7 +267,8 @@ class ImagePoolHandler {
                     width: data.width,
                     height: data.height,
                     imageDataBase64: data.image_data, // Base64 string
-                    existingMasks: data.masks // Array of mask layer objects from DB
+                    existingMasks: data.masks, // Array of mask layer objects from DB
+                    status: data.status
                 });
                 this.uiManager.clearGlobalStatus();
                 this.currentImageIndex = this.imageList.findIndex(img => img.image_hash === data.image_hash);
@@ -280,6 +282,7 @@ class ImagePoolHandler {
             this.uiManager.showGlobalStatus(`Error loading image: ${error.message}`, 'error');
             console.error("ImagePoolHandler: Select image error", error);
             this.stateManager.setActiveImage(null, null); // Clear active image on error
+            this.Utils.dispatchCustomEvent('active-image-cleared', {});
             this._updateCurrentImageDisplay();
         } finally {
             if (this.latestImageRequestHash === requestedHash) {
@@ -352,6 +355,7 @@ class ImagePoolHandler {
         this.imageList = [];
         this.currentImageIndex = -1;
         this.stateManager.setActiveImage(null, null);
+        this.Utils.dispatchCustomEvent('active-image-cleared', {});
         this._updateCurrentImageDisplay();
         // Clear pagination too if implemented
     }

--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -76,6 +76,11 @@ class ImagePoolHandler {
                 this.loadAndDisplayImagePool(1, this.currentStatusFilter);
             }
         });
+        document.addEventListener('image-status-updated', () => {
+             if (this.stateManager.getActiveProjectId()) {
+                this.loadAndDisplayImagePool(this.currentPage, this.currentStatusFilter);
+            }
+        });
     }
 
     _setupEventListeners() {

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -814,7 +814,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!projectId || !imageHash) return;
         try {
             const res = sync
-                ? await apiClient.syncImageStatusWithLayers(projectId, imageHash)
+                ? await apiClient.updateImageStatus(projectId, imageHash, 'sync_with_layers')
                 : await apiClient.updateImageStatus(projectId, imageHash, status);
             if (res.success) {
                 const finalStatus = res.status || status;

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -97,6 +97,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const reviewApproveBtn = document.getElementById('review-approve-btn');
     const reviewRejectBtn = document.getElementById('review-reject-btn');
 
+    updateStatusToggleUI('unprocessed', false);
+
     if (openAutoMaskOverlayBtn && autoMaskOverlay) {
         openAutoMaskOverlayBtn.addEventListener('click', () => utils.showElement(autoMaskOverlay, 'flex'));
     }
@@ -192,6 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
             configPath: projectData?.settings?.current_sam_config_path || null,
             applyPostprocessing: projectData?.settings?.current_sam_apply_postprocessing === 'true'
         });
+        updateStatusToggleUI('unprocessed', false);
     });
 
     document.addEventListener('project-loaded', async (event) => {
@@ -212,10 +215,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         if (imagePoolHandler) imagePoolHandler.loadAndDisplayImagePool();
         await restoreSessionFromServer();
+        updateStatusToggleUI('unprocessed', false);
     });
 
     document.addEventListener('project-load-failed', (event) => {
         uiManager.showGlobalStatus(`Failed to load project: ${utils.escapeHTML(event.detail.error)}`, 'error');
+        updateStatusToggleUI('unprocessed', false);
     });
 
 
@@ -778,23 +783,28 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    function updateStatusToggleUI(status) {
+    function updateStatusToggleUI(status, enabled = true) {
         if (readySwitch) {
             readySwitch.checked = status === 'ready_for_review';
+            readySwitch.disabled = !enabled || (skipSwitch && skipSwitch.checked);
         }
         if (skipSwitch) {
             skipSwitch.checked = status === 'skip';
-            if (readySwitch) readySwitch.disabled = skipSwitch.checked;
+            skipSwitch.disabled = !enabled;
         }
     }
 
     document.addEventListener('active-image-set', (event) => {
-        updateStatusToggleUI(event.detail.status || 'unprocessed');
+        updateStatusToggleUI(event.detail.status || 'unprocessed', true);
+    });
+
+    document.addEventListener('active-image-cleared', () => {
+        updateStatusToggleUI('unprocessed', false);
     });
 
     document.addEventListener('image-status-updated', (event) => {
         if (event.detail && event.detail.status) {
-            updateStatusToggleUI(event.detail.status);
+            updateStatusToggleUI(event.detail.status, true);
         }
     });
 

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -400,9 +400,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     num_boxes: data.num_boxes,
                     multimask_output: data.multimask_output
                 });
-                if (data.image_status) {
-                    utils.dispatchCustomEvent('image-status-updated', { imageHash: imageHashForAPI, status: data.image_status });
-                }
             } else {
                 throw new Error(data.error || "Interactive prediction API error.");
             }

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -270,14 +270,14 @@
                     </div>
                     <div id="image-status-controls" class="image-status-controls">
                         <label class="switch-control">
-                            <input type="checkbox" id="ready-switch">
-                            <span class="switch-slider"></span>
-                            <span class="switch-label-text">Ready</span>
-                        </label>
-                        <label class="switch-control">
                             <input type="checkbox" id="skip-switch">
                             <span class="switch-slider"></span>
                             <span class="switch-label-text">Skip</span>
+                        </label>
+                        <label class="switch-control">
+                            <input type="checkbox" id="ready-switch">
+                            <span class="switch-slider"></span>
+                            <span class="switch-label-text">Ready</span>
                         </label>
                     </div>
                     <div id="review-mode-controls" class="review-mode-controls" style="display:none;">

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -268,6 +268,21 @@
                     <div id="layer-view-container">
                         <p><em>No layers yet. Use "Add to Layers".</em></p>
                     </div>
+                    <div id="image-status-controls" class="image-status-controls">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="ready-switch">
+                            Ready
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="skip-switch">
+                            Skip
+                        </label>
+                    </div>
+                    <div id="review-mode-controls" class="review-mode-controls" style="display:none;">
+                        <button id="review-skip-btn">Skip</button>
+                        <button id="review-approve-btn">Approve</button>
+                        <button id="review-reject-btn">Reject</button>
+                    </div>
                     <div class="export-controls">
                         <button id="save-masks-btn" title="Download a PNG preview of the current canvas with overlays">Save Overlay Preview</button>
                         <button id="export-coco-btn" title="Export selected/all project data in COCO format">Export COCO JSON</button>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -269,13 +269,15 @@
                         <p><em>No layers yet. Use "Add to Layers".</em></p>
                     </div>
                     <div id="image-status-controls" class="image-status-controls">
-                        <label class="checkbox-label">
+                        <label class="switch-control">
                             <input type="checkbox" id="ready-switch">
-                            Ready
+                            <span class="switch-slider"></span>
+                            <span class="switch-label-text">Ready</span>
                         </label>
-                        <label class="checkbox-label">
+                        <label class="switch-control">
                             <input type="checkbox" id="skip-switch">
-                            Skip
+                            <span class="switch-slider"></span>
+                            <span class="switch-label-text">Skip</span>
                         </label>
                     </div>
                     <div id="review-mode-controls" class="review-mode-controls" style="display:none;">

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -32,6 +32,7 @@ It will be updated as new sprints add functionality.
   reverts to `unprocessed`.
 - **Image Pool Refresh**: Status update events now trigger the image pool to reload so changes are visible immediately.
 - **Bug Fix**: Removing the final mask layer now correctly changes the image status back to `unprocessed`.
+- **Status Toggles**: The annotation view now has "Ready" and "Skip" switches to update image status, dispatching refresh events.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded
@@ -69,7 +70,7 @@ It will be updated as new sprints add functionality.
    - Update export and filtering logic to handle the full status lifecycle.
 5. **Incremental Enhancements**
    - Persist `display_color` and label information when adding layers.
-   - Add update-status dropdown in the annotation view.
+   - ~~Add update-status dropdown in the annotation view.~~ Implemented as Ready/Skip toggle switches.
    - Improve error handling and autosave of `ActiveImageState` to prevent data
      loss.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -32,7 +32,7 @@ It will be updated as new sprints add functionality.
   reverts to `unprocessed`.
 - **Image Pool Refresh**: Status update events now trigger the image pool to reload so changes are visible immediately.
 - **Bug Fix**: Removing the final mask layer now correctly changes the image status back to `unprocessed`.
-- **Status Toggles**: The annotation view now has "Ready" and "Skip" switches to update image status, dispatching refresh events.
+- **Status Toggles**: The annotation view now has "Ready" and "Skip" switches to update image status, dispatching refresh events. Switches are automatically updated when a new image loads and disabled when no image is active.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -21,14 +21,14 @@ It will be updated as new sprints add functionality.
   `pycocotools` for RLE conversion.
 - **Database Helpers**: Added `get_image_hashes_by_statuses` and
   `get_layers_by_image_and_statuses` for more efficient export queries.
+- **Image Status Handling**: Backend uses the new status values
+  (`unprocessed`, `in_progress`, `ready_for_review`, `approved`, `rejected`, `skip`)
+  instead of the legacy `in_progress_auto`, `in_progress_manual` and `completed`.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded
   layers, but it lacks the complete structure (creation/edit objects) and direct
   synchronization with the backend as described.
-- **Image Status Handling**: Frontend shows new statuses, but the database schema
-  and backend still use the previous status values
-  (`in_progress_auto`, `in_progress_manual`, `completed`).
 - **Layer Data Schema**: Layers are stored with the old `layer_type` field and do
   not yet include `class_label`, `status` (prediction/edited/approved),
   `display_color`, or `source_metadata` columns.

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -31,6 +31,7 @@ It will be updated as new sprints add functionality.
 - **Status Reversion**: When all mask layers are removed from an image, its status automatically
   reverts to `unprocessed`.
 - **Image Pool Refresh**: Status update events now trigger the image pool to reload so changes are visible immediately.
+- **Bug Fix**: Removing the final mask layer now correctly changes the image status back to `unprocessed`.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -26,6 +26,9 @@ It will be updated as new sprints add functionality.
   instead of the legacy `in_progress_auto`, `in_progress_manual` and `completed`.
 - **Automatic Status Updates**: Backend now keeps an image at `in_progress` when masks are
   committed or predictions are generated, unless the client explicitly sets a higher status.
+- **Status Reversion**: When all mask layers are removed from an image, its status automatically
+  reverts to `unprocessed`.
+- **Image Pool Refresh**: Status update events now trigger the image pool to reload so changes are visible immediately.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -24,8 +24,10 @@ It will be updated as new sprints add functionality.
 - **Image Status Handling**: Backend uses the new status values
   (`unprocessed`, `in_progress`, `ready_for_review`, `approved`, `rejected`, `skip`)
   instead of the legacy `in_progress_auto`, `in_progress_manual` and `completed`.
-- **Automatic Status Updates**: Backend now keeps an image at `in_progress` when masks are
-  committed or predictions are generated, unless the client explicitly sets a higher status.
+- **Automatic Status Updates**: Image status now syncs with mask layers. Adding or
+  committing layers moves the image to `in_progress` (unless it is `skip`),
+  and removing all layers reverts it to `unprocessed`. Interactive predictions
+  alone no longer change the status.
 - **Status Reversion**: When all mask layers are removed from an image, its status automatically
   reverts to `unprocessed`.
 - **Image Pool Refresh**: Status update events now trigger the image pool to reload so changes are visible immediately.

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -33,6 +33,7 @@ It will be updated as new sprints add functionality.
 - **Image Pool Refresh**: Status update events now trigger the image pool to reload so changes are visible immediately.
 - **Bug Fix**: Removing the final mask layer now correctly changes the image status back to `unprocessed`.
 - **Status Toggles**: The annotation view now has "Ready" and "Skip" switches to update image status, dispatching refresh events. Switches are automatically updated when a new image loads and disabled when no image is active.
+- **Status Sync**: Turning a switch off now uses a `sync_with_layers` update so the status reverts to `in_progress` or `unprocessed` depending on existing masks.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -24,6 +24,8 @@ It will be updated as new sprints add functionality.
 - **Image Status Handling**: Backend uses the new status values
   (`unprocessed`, `in_progress`, `ready_for_review`, `approved`, `rejected`, `skip`)
   instead of the legacy `in_progress_auto`, `in_progress_manual` and `completed`.
+- **Automatic Status Updates**: Backend now keeps an image at `in_progress` when masks are
+  committed or predictions are generated, unless the client explicitly sets a higher status.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -268,7 +268,10 @@ The system will employ a client-server architecture.
     *   Receives the committed mask data.
     *   Converts binary masks to a storage-efficient format (e.g., COCO RLE).
     *   Persists this as a "final_edited" layer or updates an existing "final" layer in the Project State DB for the `image_hash`.
-    *   Updates the image status to `in_progress` by default. Clients may set a higher status (e.g., `ready_for_review`) via the dedicated status endpoint.
+    *   After saving the masks, the server synchronizes the image status with
+        existing mask layers. If there is at least one layer, the status becomes
+        `in_progress` (unless already `skip`); if all layers are removed later it
+        reverts to `unprocessed`.
 *   **Server Response:** `{"success": true, "message": "Masks committed.", "final_layer_id": "final_edit_uuid"}`
 *   **Client:** Updates UI, possibly locks the committed masks from further easy editing or shows them distinctly.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -361,7 +361,7 @@ The system will employ a client-server architecture.
     *   `path_in_source` (TEXT) - Relative path or identifier within the source. For uploads, this is the server path.
     *   `width` (INTEGER)
     *   `height` (INTEGER)
-    *   `status` (TEXT, e.g., "unprocessed", "in_progress_auto", "in_progress_manual", "completed")
+    *   `status` (TEXT, e.g., "unprocessed", "in_progress", "ready_for_review", "approved", "rejected", "skip")
     *   `added_to_pool_at` (TIMESTAMP)
     *   `last_processed_at` (TIMESTAMP, nullable)
     *   `notes` (TEXT, nullable)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -214,7 +214,7 @@ The system will employ a client-server architecture.
         OR `{"success": true, "message": "No more unprocessed images"}`
     *   **Client:** Loads new image onto canvas, displays existing masks, updates UI.
 *   **Set Image Status:**
-    *   **Client:** Below the layer list two toggle switches allow setting the status to **Ready** for review or **Skip**. Turning on Skip disables the Ready switch. Toggling either switch sends an update to the server.
+*   **Client:** Below the layer list two toggle switches allow setting the status to **Ready** for review or **Skip**. Turning on Skip disables the Ready switch. When a new image loads, the switches reflect its current status; if no image is loaded they are disabled. Toggling either switch sends an update to the server.
     *   **Client Request:** `PUT /api/project/<project_id>/images/<image_hash>/status` with `{"status": "ready_for_review"}` or `{"status": "skip"}`. Turning a switch off sends `{"status": "in_progress"}` if masks exist.
     *   **Server:** Updates the status in the Project State DB.
     *   **Server Response:** `{"success": true, "message": "Image status updated."}`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -325,6 +325,7 @@ The system will employ a client-server architecture.
 *   `POST /api/project/<project_id>/images/<image_hash>/predict_interactive`
 *   `POST /api/project/<project_id>/images/<image_hash>/commit_masks`
 *   `GET /api/project/<project_id>/images/<image_hash>/masks` (Get all mask layers for an image)
+*   `DELETE /api/project/<project_id>/images/<image_hash>/layers/<layer_id>` (Delete a specific mask layer)
 
 **Export:**
 *   `POST /api/project/<project_id>/export`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -213,12 +213,12 @@ The system will employ a client-server architecture.
         OR `{"success": false, "error": "Image not found or inaccessible"}` (if source is down)
         OR `{"success": true, "message": "No more unprocessed images"}`
     *   **Client:** Loads new image onto canvas, displays existing masks, updates UI.
-*   **Mark Image Status:**
-    *   **Client:** User clicks "Mark as Completed." (Or implicitly "In Progress" when an edit is made).
-    *   **Client Request:** `PUT /api/project/<project_id>/images/<image_hash>/status` (Body: `{"status": "completed"}`)
-    *   **Server:** Updates image status in Project State DB.
-    *   **Server Response:** `{"success": true, "message": "Status updated."}`
-    *   **Client:** Updates UI indicator.
+*   **Set Image Status:**
+    *   **Client:** Below the layer list two toggle switches allow setting the status to **Ready** for review or **Skip**. Turning on Skip disables the Ready switch. Toggling either switch sends an update to the server.
+    *   **Client Request:** `PUT /api/project/<project_id>/images/<image_hash>/status` with `{"status": "ready_for_review"}` or `{"status": "skip"}`. Turning a switch off sends `{"status": "in_progress"}` if masks exist.
+    *   **Server:** Updates the status in the Project State DB.
+    *   **Server Response:** `{"success": true, "message": "Image status updated."}`
+    *   **Client:** Dispatches `image-status-updated` so the image pool refreshes.
 
 **4.5. Image Annotation Workflow**
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -215,9 +215,9 @@ The system will employ a client-server architecture.
     *   **Client:** Loads new image onto canvas, displays existing masks, updates UI.
 *   **Set Image Status:**
 *   **Client:** Below the layer list two toggle switches allow setting the status to **Ready** for review or **Skip**. Turning on Skip disables the Ready switch. When a new image loads, the switches reflect its current status; if no image is loaded they are disabled. Toggling either switch sends an update to the server.
-    *   **Client Request:** `PUT /api/project/<project_id>/images/<image_hash>/status` with `{"status": "ready_for_review"}` or `{"status": "skip"}`. Turning a switch off sends `{"status": "in_progress"}` if masks exist.
-    *   **Server:** Updates the status in the Project State DB.
-    *   **Server Response:** `{"success": true, "message": "Image status updated."}`
+    *   **Client Request:** `PUT /api/project/<project_id>/images/<image_hash>/status` with `{"status": "ready_for_review"}` or `{"status": "skip"}`. Turning a switch off sends `{"status": "sync_with_layers"}` to revert to `in_progress` or `unprocessed` based on existing masks.
+    *   **Server:** Updates the status in the Project State DB, or synchronizes with mask layers when `status` is `sync_with_layers`.
+    *   **Server Response:** `{"success": true, "status": "in_progress"}` (or resulting status)
     *   **Client:** Dispatches `image-status-updated` so the image pool refreshes.
 
 **4.5. Image Annotation Workflow**
@@ -319,7 +319,7 @@ The system will employ a client-server architecture.
 *   `GET /api/project/<project_id>/images` (List/gallery images from pool, with pagination/filters)
 *   `GET /api/project/<project_id>/images/next_unprocessed?current_image_hash=<optional_hash>`
 *   `POST /api/project/<project_id>/images/set_active` (Set current image for annotation)
-*   `PUT /api/project/<project_id>/images/<image_hash>/status` (Update image status)
+*   `PUT /api/project/<project_id>/images/<image_hash>/status` (Update image status; payload `{"status": "sync_with_layers"}` reverts based on current mask layers)
 *   `GET /api/project/<project_id>/images/<image_hash>/data` (Fetch raw image data if not sent with set_active) - *Potentially combined with set_active*
 *   `GET /api/image/thumbnail/<project_id>/<image_hash>` (For gallery view - server generates on demand or pre-generates)
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -268,7 +268,7 @@ The system will employ a client-server architecture.
     *   Receives the committed mask data.
     *   Converts binary masks to a storage-efficient format (e.g., COCO RLE).
     *   Persists this as a "final_edited" layer or updates an existing "final" layer in the Project State DB for the `image_hash`.
-    *   Updates the image status to "in_progress" or "completed" based on user action.
+    *   Updates the image status to `in_progress` by default. Clients may set a higher status (e.g., `ready_for_review`) via the dedicated status endpoint.
 *   **Server Response:** `{"success": true, "message": "Masks committed.", "final_layer_id": "final_edit_uuid"}`
 *   **Client:** Updates UI, possibly locks the committed masks from further easy editing or shows them distinctly.
 


### PR DESCRIPTION
## Summary
- support new image status lifecycle in backend
- document new statuses in code and docs
- track progress in annotation workflow docs

## Testing
- `python -m py_compile app/backend/db_manager.py app/backend/project_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_684d9030fb1c83209be8815e90f514f7