### PR TITLE
Implement simple review workflow

### DIFF
--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -733,6 +733,18 @@ input[type="file"]#image-upload {
 .review-mode-controls #review-skip-btn { background-color: #6c757d; color: #fff; }
 .review-mode-controls #review-approve-btn { background-color: #28a745; color: #fff; }
 .review-mode-controls #review-reject-btn { background-color: #dc3545; color: #fff; }
+#toggle-review-mode-btn {
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    background-color: #17a2b8;
+    color: #fff;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    margin-top: 10px;
+}
+#toggle-review-mode-btn.review-active { background-color: #6c757d; }
 
 
 /* Layer View */

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -176,6 +176,12 @@ class APIClient {
         if (currentImageHash) query = `?current_image_hash=${currentImageHash}`;
         return this._request(`/project/${projectId}/images/next_unprocessed${query}`);
     }
+    async getNextImageByStatus(projectId, statuses, currentImageHash = null) {
+        const statusParam = Array.isArray(statuses) ? statuses.join(',') : String(statuses);
+        let query = `?statuses=${encodeURIComponent(statusParam)}`;
+        if (currentImageHash) query += `&current_image_hash=${currentImageHash}`;
+        return this._request(`/project/${projectId}/images/next_by_status${query}`);
+    }
     async setActiveImage(projectId, imageHash) {
         // This endpoint returns image data, dimensions, existing masks, etc.
         return this._request(`/project/${projectId}/images/set_active`, 'POST', { image_hash: imageHash });

--- a/app/frontend/static/js/imagePoolHandler.js
+++ b/app/frontend/static/js/imagePoolHandler.js
@@ -311,6 +311,26 @@ class ImagePoolHandler {
         }
     }
 
+    async loadNextImageByStatuses(statuses) {
+        const projectId = this.stateManager.getActiveProjectId();
+        if (!projectId) return;
+
+        this.uiManager.showGlobalStatus("Fetching next image...", "loading", 0);
+        const currentHash = this.stateManager.getActiveImageHash();
+        try {
+            const data = await this.apiClient.getNextImageByStatus(projectId, statuses, currentHash);
+            if (data.success && data.image_hash) {
+                await this.handleSelectImage(data.image_hash);
+            } else if (data.success && data.message) {
+                this.uiManager.showGlobalStatus(data.message, 'info');
+            } else {
+                throw new Error(data.error || 'Failed to get next image.');
+            }
+        } catch (error) {
+            this.uiManager.showGlobalStatus(`Error: ${error.message}`, 'error');
+        }
+    }
+
     async handleUpdateImageStatus(imageHash, newStatus) { // Called from main.js or other modules
         const projectId = this.stateManager.getActiveProjectId();
         if (!projectId) return;

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -289,6 +289,7 @@
                         <button id="save-masks-btn" title="Download a PNG preview of the current canvas with overlays">Save Overlay Preview</button>
                         <button id="export-coco-btn" title="Export selected/all project data in COCO format">Export COCO JSON</button>
                     </div>
+                    <button id="toggle-review-mode-btn" style="margin-top:10px;">Start Review</button>
                 </div>
             </div>
         </div>

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -46,6 +46,7 @@ It will be updated as new sprints add functionality.
 - **Prediction Clearing**: Selecting layers or adding empty layers now clears creation inputs using `canvasManager.clearAllCanvasInputs`.
 - **Default Mode on Load**: Loading an image now enters Edit mode if layers exist and skips legacy prediction data, preventing stray red masks from appearing.
 - **Legacy Prediction Removal**: Old code paths for restoring saved prediction masks have been deleted. Existing masks always load as layers.
+- **Review Mode**: Added controls to cycle through images marked `ready_for_review` with Approve/Reject/Skip actions.
 
 ## Partially Implemented / In Progress
 - **Active Image State**: `main.js` keeps a basic `activeImageState` with loaded
@@ -56,7 +57,6 @@ It will be updated as new sprints add functionality.
   `display_color`, or `source_metadata` columns.
 - **Edit Mode Tools**: Selecting a layer only displays its mask; brush/eraser,
   lasso, and other edit tools have not been implemented.
-- **Review Mode Interface**: No dedicated review workflow exists yet.
 
 ## Planned Tasks (Priority Order)
 1. **Database and API Refactor**


### PR DESCRIPTION
## Summary
- support fetching images by status
- add frontend review mode controls
- implement review cycling logic
- update documentation for new feature

## Testing
- `python -m py_compile app/backend/db_manager.py app/backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1ebb2c7083208318aa4cdd786e6d