### PR TITLE
UI control tweaks and button style cleanup

### DIFF
--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -4,7 +4,7 @@
 /* Canvas Toolbar (specific to canvas interactions) */
 .canvas-toolbar {
   display: grid;
-  grid-template-columns: 10% 45% 40% 1% 1%; /* Make room for gap */
+  grid-template-columns: 38% 20% 38%; /* 3 column layout */
   gap: 8px;
   padding: 6px 10px;
   background-color: #f8f9fa;
@@ -15,21 +15,46 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
+.canvas-toolbar-button-column {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: stretch; /* Changed from center to stretch */
+    width: 100%; /* Ensure full width usage */
+    padding: 0px;
+}
+
+/* Make text buttons stretch to fill available width equally */
+.canvas-toolbar-button-column .text-btn {
+    flex: 1; /* Grow to fill available space */
+    min-width: 0; /* Allow shrinking if needed */
+    width: 100%; /* Take full width of container */
+}
+
+/* Keep icon buttons at their natural size */
+.canvas-toolbar-button-column .icon-btn {
+    flex: 0 0 auto; /* Don't grow or shrink, keep natural size */
+    align-self: center; /* Center icon buttons within the column */
+}
+
 .toolbar-col,
 .toolbar-col-1,
 .toolbar-col-2,
-.toolbar-col-3,
-.toolbar-col-4,
-.toolbar-col-5 {
+.toolbar-col-3 {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 10px;
 }
 
+.toolbar-col-2 {
+  gap: 1px; /* Smaller gap between button columns in the center toolbar column */
+}
+
 .left-controls {
   flex-direction: row;
   align-items: center;
+  justify-content: center;
 }
 
 .mask-toggle-container {
@@ -259,13 +284,16 @@
 @media (max-width: 768px) {
   .canvas-toolbar {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
   }
   .toolbar-col,
   .toolbar-col-1,
   .toolbar-col-2,
-  .toolbar-col-3,
-  .toolbar-col-4,
-  .toolbar-col-5 {
+  .toolbar-col-3 {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .left-controls {
     flex-direction: column;
     align-items: stretch;
   }

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -5,8 +5,8 @@
 .canvas-toolbar {
   display: grid;
   grid-template-columns: 10% 45% 40% 1% 1%; /* Make room for gap */
-  gap: 10px;
-  padding: 10px 15px;
+  gap: 8px;
+  padding: 6px 10px;
   background-color: #f8f9fa;
   border-radius: 6px;
   align-items: center;
@@ -28,8 +28,8 @@
 }
 
 .left-controls {
-  flex-direction: column;
-  align-items: stretch;
+  flex-direction: row;
+  align-items: center;
 }
 
 .mask-toggle-container {

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -112,6 +112,39 @@ header p {
   height: 100%;
   min-height: 0;
 }
+
+/* Base button styles */
+.text-btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+.text-btn:disabled {
+  cursor: not-allowed;
+  background-color: #adb5bd;
+}
+
+.icon-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.icon-btn:disabled {
+  background-color: #adb5bd;
+  cursor: not-allowed;
+}
 .layer-view-section {
   width: auto;
   flex: 1;
@@ -575,32 +608,25 @@ ul.image-sources-list li span {
 
 /* Image Pool Controls */
 .image-pool-controls,
-.image-pool-filters {
+.image-pool-toolbar {
   display: flex;
   align-items: center;
   gap: 10px;
   margin-bottom: 5px;
   flex-wrap: wrap;
 }
-.image-pool-controls button,
-.image-pool-filters button {
-  padding: 8px 12px;
+.image-pool-controls .text-btn,
+.image-pool-toolbar .text-btn {
   background-color: #6c757d;
   color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  transition: background-color 0.2s;
 }
-.image-pool-controls button:hover:not(:disabled),
-.image-pool-filters button:hover:not(:disabled) {
+.image-pool-controls .text-btn:hover:not(:disabled),
+.image-pool-toolbar .text-btn:hover:not(:disabled) {
   background-color: #5a6268;
 }
-.image-pool-controls button:disabled,
-.image-pool-filters button:disabled {
+.image-pool-controls .text-btn:disabled,
+.image-pool-toolbar .text-btn:disabled {
   background-color: #adb5bd;
-  cursor: not-allowed;
 }
 
 #current-image-info {
@@ -610,11 +636,11 @@ ul.image-sources-list li span {
   min-width: 150px;
   text-align: center;
 }
-.image-pool-filters label {
+.image-pool-toolbar label {
   font-weight: 500;
   font-size: 14px;
 }
-.image-pool-filters select {
+.image-pool-toolbar select {
   padding: 8px 10px;
   border: 1px solid #ced4da;
   border-radius: 4px;
@@ -971,31 +997,6 @@ input[type="file"]#image-upload {
 }
 
 /* Results & Export Controls */
-.export-controls {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-top: 15px;
-}
-.export-controls button {
-  padding: 6px 12px;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-.export-controls .icon-btn {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-}
 .sr-only {
   position: absolute;
   width: 1px;
@@ -1007,28 +1008,32 @@ input[type="file"]#image-upload {
   border: 0;
 }
 /* Individual button colors */
-#save-masks-btn {
+#save-canvas-png-btn {
   background-color: #007bff;
 } /* Blue for preview */
-#save-masks-btn:hover:not(:disabled) {
+#save-canvas-png-btn:hover:not(:disabled) {
   background-color: #0056b3;
 }
 #commit-masks-btn {
   background-color: #28a745;
+  padding: 8px 16px;
+  font-size: 15px;
 } /* Green for commit */
 #commit-masks-btn:hover:not(:disabled) {
   background-color: #218838;
 }
-#export-coco-btn {
+#open-export-btn {
   background-color: #fd7e14;
 } /* Orange for COCO export */
-#export-coco-btn:hover:not(:disabled) {
+#open-export-btn:hover:not(:disabled) {
   background-color: #e06200;
 }
-
-.export-controls button:disabled {
-  background-color: #adb5bd;
-  cursor: not-allowed;
+#open-auto-mask-overlay {
+  background-color: #6c757d;
+  color: #fff;
+}
+#open-auto-mask-overlay:hover:not(:disabled) {
+  background-color: #5a6268;
 }
 
 /* Image Status Controls */
@@ -1067,7 +1072,7 @@ input[type="file"]#image-upload {
   background-color: #dc3545;
   color: #fff;
 }
-#toggle-review-mode-btn {
+#review-mode-btn {
   padding: 6px 12px;
   border: none;
   border-radius: 4px;
@@ -1077,7 +1082,7 @@ input[type="file"]#image-upload {
   font-size: 13px;
   font-weight: 500;
 }
-#toggle-review-mode-btn.review-active {
+#review-mode-btn.review-active {
   background-color: #6c757d;
 }
 
@@ -1249,9 +1254,6 @@ input[type="file"]#image-upload {
     width: 100%;
     margin-top: 10px;
   }
-  .export-controls button {
-    width: 100%;
-  }
 }
 @media (max-width: 900px) {
   .image-section {
@@ -1271,13 +1273,13 @@ input[type="file"]#image-upload {
     width: 100%;
   }
   .image-pool-controls,
-  .image-pool-filters {
+  .image-pool-toolbar {
     flex-direction: column;
     align-items: stretch;
   }
   .image-pool-controls button,
-  .image-pool-filters button,
-  .image-pool-filters select {
+  .image-pool-toolbar button,
+  .image-pool-toolbar select {
     width: 100%;
   }
 }

--- a/app/frontend/static/js/exportDialog.js
+++ b/app/frontend/static/js/exportDialog.js
@@ -12,7 +12,7 @@ class ExportDialog {
 
     this.overlay = document.getElementById("export-overlay");
     this.closeBtn = document.getElementById("close-export-overlay");
-    this.openBtn = document.getElementById("export-coco-btn");
+    this.openBtn = document.getElementById("open-export-btn");
     this.imageScopeRadios = document.getElementsByName("export-image-scope");
     this.statusSection = document.getElementById("export-status-section");
     this.statusInput = document.getElementById("export-status-input");

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -107,9 +107,9 @@ document.addEventListener("DOMContentLoaded", () => {
     ),
     statusEl: document.getElementById("auto-mask-status"),
   };
-  const saveOverlayBtn = document.getElementById("save-masks-btn");
+  const saveOverlayBtn = document.getElementById("save-canvas-png-btn");
   const commitMasksBtn = document.getElementById("commit-masks-btn");
-  const exportCocoBtn = document.getElementById("export-coco-btn");
+  const openExportBtn = document.getElementById("open-export-btn");
   const addEmptyLayerBtn = document.getElementById("add-empty-layer-btn");
   const readySwitch = document.getElementById("ready-switch");
   const skipSwitch = document.getElementById("skip-switch");
@@ -117,7 +117,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const reviewApproveBtn = document.getElementById("review-approve-btn");
   const reviewRejectBtn = document.getElementById("review-reject-btn");
   const reviewPrevBtn = document.getElementById("review-prev-btn");
-  const toggleReviewModeBtn = document.getElementById("toggle-review-mode-btn");
+  const toggleReviewModeBtn = document.getElementById("review-mode-btn");
   const reviewModeControls = document.getElementById("review-mode-controls");
   const imageStatusControls = document.getElementById("image-status-controls");
 

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -240,30 +240,42 @@
                 </div>
 
             <div class="image-section">
-                    <div class="image-display-area">
-                        <div class="canvas-container">
-                            <canvas id="image-canvas"></canvas>
-                            <canvas id="prediction-mask-canvas"></canvas>
-                            <canvas id="user-input-canvas"></canvas>
-                            <div id="canvas-lock" class="canvas-lock-overlay">
-                                <div class="canvas-lock-content">
-                                    <div class="spinner"></div>
-                                    <div class="canvas-lock-message">Processing...</div>
-                                </div>
+                <div class="image-display-area">
+                    <div class="canvas-container">
+                        <canvas id="image-canvas"></canvas>
+                        <canvas id="prediction-mask-canvas"></canvas>
+                        <canvas id="user-input-canvas"></canvas>
+                        <div id="canvas-lock" class="canvas-lock-overlay">
+                            <div class="canvas-lock-content">
+                                <div class="spinner"></div>
+                                <div class="canvas-lock-message">Processing...</div>
                             </div>
                         </div>
-                        <div class="canvas-toolbar">
-                            <div class="toolbar-col-1 toolbar-col left-controls">
-                                <button id="clear-inputs-btn" class="text-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
+                    </div>
+                    <div class="canvas-toolbar">
+                        <!-- Left Column (40%) - Mask Toggle Container -->
+                        <div class="toolbar-col-1 toolbar-col">
+                            <div id="mask-toggle-container" class="mask-toggle-container"></div>
+                        </div>
+                        
+                        <!-- Middle Column (20%) - Button Columns -->
+                        <div class="toolbar-col-2 toolbar-col left-controls">
+                            <div class="canvas-toolbar-button-column">
+                                <button id="commit-masks-btn" class="text-btn" title="Add the current predictions to the Layer View">Add</button>
+                                <button id="clear-inputs-btn" class="text-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear</button>
+                            </div>
+                            <div class="canvas-toolbar-button-column">
                                 <button id="open-auto-mask-overlay" class="icon-btn" title="Automatic mask generation">
                                     <span class="icon">🪄</span><span class="sr-only">AutoMask</span>
                                 </button>
-                                <button id="commit-masks-btn" class="text-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
+                                <button id="save-canvas-png-btn" class="icon-btn" title="Download a PNG preview of the current canvas with overlays">
+                                    <span class="icon">💾</span><span class="sr-only">Save PNG</span>
+                                </button>
                             </div>
-                        <div class="toolbar-col-2 toolbar-col">
-                            <div id="mask-toggle-container" class="mask-toggle-container"></div>
                         </div>
-                        <div class="toolbar-col-3 toolbar-col help-section">
+                        
+                        <!-- Right Column (40%) - Opacity Controls -->
+                        <div class="toolbar-col-3 toolbar-col">
                             <div class="opacity-controls">
                                 <div class="opacity-control">
                                     <label for="image-opacity">Image</label>
@@ -297,9 +309,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="toolbar-col-4 toolbar-col future-tools"></div>
-                        <div class="toolbar-col-5 toolbar-col">
-                        </div>
                     </div>
                 </div>
                 <div id="layer-view-section" class="layer-view-section">
@@ -318,9 +327,6 @@
                             <span class="switch-slider"></span>
                             <span class="switch-label-text">Ready</span>
                         </label>
-                        <button id="save-canvas-png-btn" class="icon-btn" title="Download a PNG preview of the current canvas with overlays">
-                            <span class="icon">💾</span><span class="sr-only">Save PNG</span>
-                        </button>
                     </div>
                     <div id="review-mode-controls" class="review-mode-controls" style="display:none;">
                         <button id="review-prev-btn" title="Go to previous reviewed image">Prev</button>
@@ -328,7 +334,6 @@
                         <button id="review-approve-btn">Approve</button>
                         <button id="review-reject-btn">Reject</button>
                     </div>
-
                 </div>
             </div>
         </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -215,7 +215,7 @@
                         <button id="next-image-btn" title="Load next image in pool">Next ></button>
                         <button id="next-unprocessed-image-btn" title="Load next unprocessed image">Next Unprocessed</button>
                     </div>
-                    <div class="image-pool-filters">
+                    <div class="image-pool-toolbar">
                         <label for="image-status-filter">Filter by status:</label>
                         <select id="image-status-filter">
                             <option value="">All</option>
@@ -226,7 +226,9 @@
                             <option value="rejected">Rejected</option>
                             <option value="skip">Skip</option>
                         </select>
-                        <button id="refresh-image-pool-btn">Refresh Pool</button>
+                        <button id="refresh-image-pool-btn" class="text-btn">Refresh Pool</button>
+                        <button id="open-export-btn" class="text-btn">Export</button>
+                        <button id="review-mode-btn" class="text-btn">Start Review</button>
                     </div>
                     <div id="image-gallery-container">
                         <p><em>Load a project to see images.</em></p>
@@ -252,9 +254,11 @@
                         </div>
                         <div class="canvas-toolbar">
                             <div class="toolbar-col-1 toolbar-col left-controls">
-                                <button id="clear-inputs-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
-                                <button id="open-auto-mask-overlay">AutoMask</button>
-                                <button id="commit-masks-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
+                                <button id="clear-inputs-btn" class="text-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear Inputs</button>
+                                <button id="open-auto-mask-overlay" class="icon-btn" title="Automatic mask generation">
+                                    <span class="icon">🪄</span><span class="sr-only">AutoMask</span>
+                                </button>
+                                <button id="commit-masks-btn" class="text-btn" title="Add the current predictions to the Layer View">Add to Layers</button>
                             </div>
                         <div class="toolbar-col-2 toolbar-col">
                             <div id="mask-toggle-container" class="mask-toggle-container"></div>
@@ -314,6 +318,9 @@
                             <span class="switch-slider"></span>
                             <span class="switch-label-text">Ready</span>
                         </label>
+                        <button id="save-canvas-png-btn" class="icon-btn" title="Download a PNG preview of the current canvas with overlays">
+                            <span class="icon">💾</span><span class="sr-only">Save PNG</span>
+                        </button>
                     </div>
                     <div id="review-mode-controls" class="review-mode-controls" style="display:none;">
                         <button id="review-prev-btn" title="Go to previous reviewed image">Prev</button>
@@ -321,15 +328,7 @@
                         <button id="review-approve-btn">Approve</button>
                         <button id="review-reject-btn">Reject</button>
                     </div>
-                    <div class="export-controls">
-                        <button id="save-masks-btn" class="icon-btn" title="Download a PNG preview of the current canvas with overlays">
-                            <span class="icon">💾</span><span class="sr-only">Save Overlay Preview</span>
-                        </button>
-                        <button id="export-coco-btn" class="icon-btn" title="Export selected/all project data in COCO format">
-                            <span class="icon">📤</span><span class="sr-only">Export COCO JSON</span>
-                        </button>
-                        <button id="toggle-review-mode-btn">Start Review</button>
-                    </div>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- move export and review mode buttons to the image pool toolbar
- rename overlay save/export/review buttons and make AutoMask an icon button
- unify text and icon button styling
- compact canvas toolbar and enlarge Add button

## Testing
- `black --check app/frontend/static/js/main.js app/frontend/static/js/exportDialog.js` *(fails: Cannot parse)*

------
https://chatgpt.com/codex/tasks/task_e_68532a487e008320a643491bc5c66785