### PR TITLE
Add minimal edit mode tools

### DIFF
--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -234,8 +234,9 @@
 /* Individual Canvases */
 .canvas-container canvas {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   border-radius: 3px; /* Slight rounding on canvas edges */
   /* box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); /* Softer shadow */
   /* Canvases will be sized by JS, these are fallbacks or if JS fails */

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -227,15 +227,15 @@
   border: 1px solid #007bff;
   border-radius: 50%;
   transform: translate(-50%, -50%);
+  z-index: 4;
   display: none;
 }
 
 /* Individual Canvases */
 .canvas-container canvas {
   position: absolute;
-  /* top: 50%; /* Centering handled by flex on parent */
-  /* left: 50%; */
-  /* transform: translate(-50%, -50%); */
+  top: 0;
+  left: 0;
   border-radius: 3px; /* Slight rounding on canvas edges */
   /* box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); /* Softer shadow */
   /* Canvases will be sized by JS, these are fallbacks or if JS fails */

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -22,18 +22,26 @@
     align-items: center;
     justify-content: center;
     width: 100%; /* Ensure full width usage */
-    padding: 0px;
+    padding: 4px;
 }
 
 /* Make text buttons stretch to fill available width equally */
 .canvas-toolbar-button-column .text-btn {
-    width: 100%;
+    flex: 1; /* Grow to fill available space */
+    min-width: 0; /* Allow shrinking if needed */
+    width: 100%; /* Take full width of container */
+    min-width: 35px;
+    min-height: 35px;
+    color: #dee2e6;
+    text-shadow: 1px 1px 1px #49505740;
 }
 
 /* Keep icon buttons at their natural size */
 .canvas-toolbar-button-column .icon-btn {
     flex: 0 0 auto; /* Don't grow or shrink, keep natural size */
     align-self: center; /* Center icon buttons within the column */
+    min-width: 35px;
+    min-height: 35px;
 }
 
 .toolbar-col,
@@ -234,9 +242,9 @@
 /* Individual Canvases */
 .canvas-container canvas {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  /* top: 50%; /* Centering handled by flex on parent */
+  /* left: 50%; */
+  /* transform: translate(-50%, -50%); */
   border-radius: 3px; /* Slight rounding on canvas edges */
   /* box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); /* Softer shadow */
   /* Canvases will be sized by JS, these are fallbacks or if JS fails */

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -19,16 +19,15 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
-    align-items: stretch; /* Changed from center to stretch */
+    align-items: center;
+    justify-content: center;
     width: 100%; /* Ensure full width usage */
     padding: 0px;
 }
 
 /* Make text buttons stretch to fill available width equally */
 .canvas-toolbar-button-column .text-btn {
-    flex: 1; /* Grow to fill available space */
-    min-width: 0; /* Allow shrinking if needed */
-    width: 100%; /* Take full width of container */
+    width: 100%;
 }
 
 /* Keep icon buttons at their natural size */

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -206,6 +206,28 @@
   width: 100%; /* Take full width of its parent */
 }
 
+.edit-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 6px;
+  margin-top: 4px;
+}
+.edit-tools,
+.edit-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.edit-toolbar button.active {
+  background-color: #007bff;
+  color: #fff;
+}
+
 /* Individual Canvases */
 .canvas-container canvas {
   position: absolute;

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -206,24 +206,13 @@
   width: 100%; /* Take full width of its parent */
 }
 
-.edit-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 10px;
-  background-color: #f8f9fa;
-  border: 1px solid #e9ecef;
-  border-radius: 6px;
-  margin-top: 4px;
-}
 .edit-tools,
 .edit-actions {
   display: flex;
   gap: 8px;
   align-items: center;
 }
-.edit-toolbar button.active {
+.edit-tools button.active {
   background-color: #007bff;
   color: #fff;
 }

--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -217,6 +217,20 @@
   color: #fff;
 }
 
+.creation-actions {
+  display: flex;
+  gap: 1px;
+}
+
+.brush-preview {
+  position: absolute;
+  pointer-events: none;
+  border: 1px solid #007bff;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  display: none;
+}
+
 /* Individual Canvases */
 .canvas-container canvas {
   position: absolute;
@@ -321,6 +335,10 @@
   }
   .canvas-container {
     min-height: 300px; /* Adjust min-height for smaller screens */
+  }
+  .creation-actions {
+    flex-direction: column;
+    width: 100%;
   }
 }
 

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -1049,7 +1049,20 @@ input[type="file"]#image-upload {
   gap: 10px;
   margin-top: 0;
 }
+.review-mode-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 0;
+}
 .review-mode-controls button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+.review-mode-actions button {
   padding: 6px 12px;
   border: none;
   border-radius: 4px;

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -854,6 +854,7 @@ input[type="file"]#image-upload {
   justify-content: center;
 }
 .help-icon {
+  position: relative;
   display: inline-block;
   width: 24px;
   height: 24px;
@@ -1046,7 +1047,7 @@ input[type="file"]#image-upload {
 .review-mode-controls {
   display: flex;
   gap: 10px;
-  margin-top: 10px;
+  margin-top: 0;
 }
 .review-mode-controls button {
   padding: 6px 12px;

--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -987,8 +987,15 @@ class CanvasManager {
     startMaskEdit(layerId, maskData, color) {
         this.editingLayerId = layerId;
         this.editingColor = color || '#ff0000';
-        if (Array.isArray(maskData) && maskData.length > 0 && Array.isArray(maskData[0])) {
+        if (Array.isArray(maskData) && Array.isArray(maskData[0])) {
             this.editingMask = maskData.map(r => Array.from(r));
+        } else if (maskData && maskData.counts && maskData.size) {
+            const converted = this.Utils.rleToBinaryMask(
+                maskData,
+                this.originalImageHeight,
+                this.originalImageWidth
+            );
+            this.editingMask = converted || this._createEmptyMask();
         } else {
             this.editingMask = this._createEmptyMask();
         }

--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -987,7 +987,7 @@ class CanvasManager {
     startMaskEdit(layerId, maskData, color) {
         this.editingLayerId = layerId;
         this.editingColor = color || '#ff0000';
-        if (Array.isArray(maskData) && Array.isArray(maskData[0])) {
+        if (Array.isArray(maskData) && maskData.length > 0 && Array.isArray(maskData[0])) {
             this.editingMask = maskData.map(r => Array.from(r));
         } else {
             this.editingMask = this._createEmptyMask();

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -76,16 +76,19 @@ class EditModeController {
     onMouseDown(e) {
         if (!this.activeLayer) return;
         this.isDrawing = true;
+        if (this.previewEl) {
+            this.previewEl.style.left = `${e.offsetX}px`;
+            this.previewEl.style.top = `${e.offsetY}px`;
+        }
         this.applyBrush(e);
         e.preventDefault();
     }
 
     onMouseMove(e) {
         if (!this.activeLayer) return;
-        const rect = this.canvasManager.userInputCanvas.getBoundingClientRect();
         if (this.previewEl) {
-            this.previewEl.style.left = `${e.clientX - rect.left}px`;
-            this.previewEl.style.top = `${e.clientY - rect.top}px`;
+            this.previewEl.style.left = `${e.offsetX}px`;
+            this.previewEl.style.top = `${e.offsetY}px`;
         }
         if (!this.isDrawing) return;
         this.applyBrush(e);
@@ -98,7 +101,8 @@ class EditModeController {
 
     applyBrush(e) {
         const coords = this.canvasManager._displayToOriginalCoords(e.clientX, e.clientY);
-        const add = !(e.button === 2 || e.ctrlKey);
+        const rightHeld = e.buttons === 2 || e.button === 2;
+        const add = !(rightHeld || e.ctrlKey);
         this.canvasManager.applyBrush(coords.x, coords.y, this.brushSize, add);
     }
 

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -28,6 +28,11 @@ class EditModeController {
         this.previewEl = document.getElementById('brush-preview');
     }
 
+    _getCanvasRelativeCoords(e) {
+        const rect = this.canvasManager.userInputCanvas.getBoundingClientRect();
+        return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+
     attachListeners() {
         if (this.brushSizeInput) this.brushSizeInput.addEventListener('input', () => {
             this.brushSize = parseInt(this.brushSizeInput.value, 10) || 1;
@@ -77,8 +82,9 @@ class EditModeController {
         if (!this.activeLayer) return;
         this.isDrawing = true;
         if (this.previewEl) {
-            this.previewEl.style.left = `${e.offsetX}px`;
-            this.previewEl.style.top = `${e.offsetY}px`;
+            const pos = this._getCanvasRelativeCoords(e);
+            this.previewEl.style.left = `${pos.x}px`;
+            this.previewEl.style.top = `${pos.y}px`;
         }
         this.applyBrush(e);
         e.preventDefault();
@@ -87,8 +93,9 @@ class EditModeController {
     onMouseMove(e) {
         if (!this.activeLayer) return;
         if (this.previewEl) {
-            this.previewEl.style.left = `${e.offsetX}px`;
-            this.previewEl.style.top = `${e.offsetY}px`;
+            const pos = this._getCanvasRelativeCoords(e);
+            this.previewEl.style.left = `${pos.x}px`;
+            this.previewEl.style.top = `${pos.y}px`;
         }
         if (!this.isDrawing) return;
         this.applyBrush(e);

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -20,7 +20,8 @@ class EditModeController {
     }
 
     initElements() {
-        this.toolbarEl = document.getElementById('edit-toolbar');
+        this.toolsContainer = document.getElementById('edit-tools');
+        this.actionsContainer = document.getElementById('edit-actions');
         this.brushBtn = document.getElementById('edit-brush-btn');
         this.eraserBtn = document.getElementById('edit-eraser-btn');
         this.brushSizeInput = document.getElementById('edit-brush-size');
@@ -55,18 +56,19 @@ class EditModeController {
         if (!layer) return;
         this.activeLayer = layer;
         this.canvasManager.startMaskEdit(layer.layerId, layer.maskData, layer.displayColor);
-        this.showToolbar(true);
+        this.showControls(true);
         this.setMode('brush');
     }
 
     endEdit() {
         this.activeLayer = null;
-        this.showToolbar(false);
+        this.showControls(false);
         this.canvasManager.finishMaskEdit();
     }
 
-    showToolbar(show) {
-        if (this.toolbarEl) this.toolbarEl.style.display = show ? 'flex' : 'none';
+    showControls(show) {
+        if (this.toolsContainer) this.toolsContainer.style.display = show ? 'flex' : 'none';
+        if (this.actionsContainer) this.actionsContainer.style.display = show ? 'flex' : 'none';
     }
 
     onMouseDown(e) {

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -28,11 +28,6 @@ class EditModeController {
         this.previewEl = document.getElementById('brush-preview');
     }
 
-    _getCanvasRelativeCoords(e) {
-        const rect = this.canvasManager.userInputCanvas.getBoundingClientRect();
-        return { x: e.clientX - rect.left, y: e.clientY - rect.top };
-    }
-
     attachListeners() {
         if (this.brushSizeInput) this.brushSizeInput.addEventListener('input', () => {
             this.brushSize = parseInt(this.brushSizeInput.value, 10) || 1;
@@ -82,20 +77,23 @@ class EditModeController {
         if (!this.activeLayer) return;
         this.isDrawing = true;
         if (this.previewEl) {
-            const pos = this._getCanvasRelativeCoords(e);
-            this.previewEl.style.left = `${pos.x}px`;
-            this.previewEl.style.top = `${pos.y}px`;
+            this.previewEl.style.position = 'fixed';
+            this.previewEl.style.left = `${e.clientX}px`;
+            this.previewEl.style.top = `${e.clientY}px`;
+            this.previewEl.style.pointerEvents = 'none';
         }
         this.applyBrush(e);
         e.preventDefault();
     }
 
+
     onMouseMove(e) {
         if (!this.activeLayer) return;
         if (this.previewEl) {
-            const pos = this._getCanvasRelativeCoords(e);
-            this.previewEl.style.left = `${pos.x}px`;
-            this.previewEl.style.top = `${pos.y}px`;
+            this.previewEl.style.position = 'fixed';
+            this.previewEl.style.left = `${e.clientX}px`;
+            this.previewEl.style.top = `${e.clientY}px`;
+            this.previewEl.style.pointerEvents = 'none';
         }
         if (!this.isDrawing) return;
         this.applyBrush(e);

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -1,0 +1,108 @@
+/**
+ * project_root/app/frontend/static/js/editModeController.js
+ *
+ * Provides a minimal edit mode toolbar with brush and eraser tools.
+ * Handles user input events on the canvas to modify the active mask
+ * via CanvasManager. Saves or cancels edits using dispatched events.
+ */
+class EditModeController {
+    constructor(canvasManager, stateManager, apiClient, utils) {
+        this.canvasManager = canvasManager;
+        this.stateManager = stateManager;
+        this.apiClient = apiClient;
+        this.utils = utils;
+        this.activeLayer = null;
+        this.mode = 'brush';
+        this.brushSize = 10;
+        this.isDrawing = false;
+        this.initElements();
+        this.attachListeners();
+    }
+
+    initElements() {
+        this.toolbarEl = document.getElementById('edit-toolbar');
+        this.brushBtn = document.getElementById('edit-brush-btn');
+        this.eraserBtn = document.getElementById('edit-eraser-btn');
+        this.brushSizeInput = document.getElementById('edit-brush-size');
+        this.saveBtn = document.getElementById('edit-save-btn');
+        this.cancelBtn = document.getElementById('edit-cancel-btn');
+    }
+
+    attachListeners() {
+        if (this.brushBtn) this.brushBtn.addEventListener('click', () => this.setMode('brush'));
+        if (this.eraserBtn) this.eraserBtn.addEventListener('click', () => this.setMode('eraser'));
+        if (this.brushSizeInput) this.brushSizeInput.addEventListener('input', () => {
+            this.brushSize = parseInt(this.brushSizeInput.value, 10) || 1;
+        });
+        if (this.saveBtn) this.saveBtn.addEventListener('click', () => this.save());
+        if (this.cancelBtn) this.cancelBtn.addEventListener('click', () => this.cancel());
+        const canvas = this.canvasManager.userInputCanvas;
+        if (canvas) {
+            canvas.addEventListener('mousedown', (e) => this.onMouseDown(e));
+            canvas.addEventListener('mousemove', (e) => this.onMouseMove(e));
+            canvas.addEventListener('mouseup', () => this.onMouseUp());
+            canvas.addEventListener('mouseleave', () => this.onMouseUp());
+        }
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+        if (this.brushBtn) this.brushBtn.classList.toggle('active', mode === 'brush');
+        if (this.eraserBtn) this.eraserBtn.classList.toggle('active', mode === 'eraser');
+    }
+
+    beginEdit(layer) {
+        if (!layer) return;
+        this.activeLayer = layer;
+        this.canvasManager.startMaskEdit(layer.layerId, layer.maskData, layer.displayColor);
+        this.showToolbar(true);
+        this.setMode('brush');
+    }
+
+    endEdit() {
+        this.activeLayer = null;
+        this.showToolbar(false);
+        this.canvasManager.finishMaskEdit();
+    }
+
+    showToolbar(show) {
+        if (this.toolbarEl) this.toolbarEl.style.display = show ? 'flex' : 'none';
+    }
+
+    onMouseDown(e) {
+        if (!this.activeLayer) return;
+        this.isDrawing = true;
+        this.applyBrush(e);
+        e.preventDefault();
+    }
+
+    onMouseMove(e) {
+        if (!this.isDrawing) return;
+        this.applyBrush(e);
+        e.preventDefault();
+    }
+
+    onMouseUp() {
+        this.isDrawing = false;
+    }
+
+    applyBrush(e) {
+        const coords = this.canvasManager._displayToOriginalCoords(e.clientX, e.clientY);
+        const add = this.mode === 'brush';
+        this.canvasManager.applyBrush(coords.x, coords.y, this.brushSize, add);
+    }
+
+    save() {
+        if (!this.activeLayer) return;
+        const edited = this.canvasManager.getEditedMask();
+        this.utils.dispatchCustomEvent('edit-save', { layerId: this.activeLayer.layerId, maskData: edited });
+        this.endEdit();
+    }
+
+    cancel() {
+        this.utils.dispatchCustomEvent('edit-cancel', {});
+        this.endEdit();
+    }
+}
+
+window.EditModeController = EditModeController;

--- a/app/frontend/static/js/exportDialog.js
+++ b/app/frontend/static/js/exportDialog.js
@@ -13,6 +13,7 @@ class ExportDialog {
     this.overlay = document.getElementById("export-overlay");
     this.closeBtn = document.getElementById("close-export-overlay");
     this.openBtn = document.getElementById("open-export-btn");
+    this.reviewOpenBtn = document.getElementById("review-export-btn");
     this.imageScopeRadios = document.getElementsByName("export-image-scope");
     this.statusSection = document.getElementById("export-status-section");
     this.statusInput = document.getElementById("export-status-input");
@@ -24,6 +25,9 @@ class ExportDialog {
 
     if (this.openBtn) {
       this.openBtn.addEventListener("click", () => this.show());
+    }
+    if (this.reviewOpenBtn) {
+      this.reviewOpenBtn.addEventListener("click", () => this.show());
     }
     if (this.closeBtn) {
       this.closeBtn.addEventListener("click", () => this.hide());

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -206,6 +206,8 @@ document.addEventListener("DOMContentLoaded", () => {
     utils.hideElement(clearInputsBtn);
     utils.hideElement(creationActions);
     utils.hideElement(editActions);
+    if (editModeController) editModeController.endEdit();
+    canvasManager.setMode("review");
     if (reviewPrevBtn) reviewPrevBtn.disabled = true;
     if (imagePoolHandler)
       imagePoolHandler.loadNextImageByStatuses(["ready_for_review"]);
@@ -227,6 +229,7 @@ document.addEventListener("DOMContentLoaded", () => {
     utils.showElement(clearInputsBtn);
     utils.showElement(creationActions, "flex");
     utils.hideElement(editActions);
+    canvasManager.setMode("creation");
     updateHelpTooltipForMode("creation");
     reviewHistory = [];
     reviewHistoryIndex = -1;
@@ -592,15 +595,8 @@ document.addEventListener("DOMContentLoaded", () => {
       const hadState = !!canvasStateCache[imageHash];
       restoreCanvasState(imageHash);
       layerViewController && layerViewController.setSelectedLayers([]);
-      if (!hadState) {
-        if (activeImageState.layers && activeImageState.layers.length > 0) {
-          canvasManager.setMode("edit", []);
-        } else {
-          canvasManager.setMode("creation");
-        }
-      } else {
-        canvasManager.setMode("edit", []);
-      }
+      if (editModeController) editModeController.endEdit();
+      canvasManager.setMode("creation");
       uiManager.clearGlobalStatus();
       onImageDataChange("image-loaded", { imageHash });
     };
@@ -1116,7 +1112,11 @@ document.addEventListener("DOMContentLoaded", () => {
       ? event.detail.layerIds
       : [];
     canvasManager.clearAllCanvasInputs(false);
-    canvasManager.setMode("edit", ids);
+    if (ids.length === 0) {
+      canvasManager.setMode("creation");
+    } else {
+      canvasManager.setMode("edit", ids);
+    }
     canvasManager.setLayers(activeImageState.layers);
     if (editModeController) {
       if (ids.length === 1) {
@@ -1290,6 +1290,7 @@ document.addEventListener("DOMContentLoaded", () => {
       onImageDataChange("layer-modified", { layerId: layer.layerId });
     }
     if (layerViewController) layerViewController.setSelectedLayers([]);
+    canvasManager.setMode("creation");
     utils.showElement(creationActions, "flex");
     utils.hideElement(editActions);
     if (!reviewMode) updateHelpTooltipForMode("creation");
@@ -1300,6 +1301,7 @@ document.addEventListener("DOMContentLoaded", () => {
       canvasManager.setLayers(activeImageState.layers);
     }
     if (layerViewController) layerViewController.setSelectedLayers([]);
+    canvasManager.setMode("creation");
     utils.showElement(creationActions, "flex");
     utils.hideElement(editActions);
     if (!reviewMode) updateHelpTooltipForMode("creation");
@@ -1319,10 +1321,14 @@ document.addEventListener("DOMContentLoaded", () => {
       activeImageState.status = event.detail.status || "unprocessed";
     }
     onImageDataChange("image-loaded", { imageHash: event.detail.imageHash });
+    if (editModeController) editModeController.endEdit();
+    canvasManager.setMode("creation");
   });
 
   document.addEventListener("active-image-cleared", () => {
     activeImageState = null;
+    if (editModeController) editModeController.endEdit();
+    canvasManager.setMode("creation");
     updateStatusToggleUI("unprocessed", false);
   });
 

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -125,6 +125,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const reviewApproveBtn = document.getElementById("review-approve-btn");
   const reviewRejectBtn = document.getElementById("review-reject-btn");
   const reviewPrevBtn = document.getElementById("review-prev-btn");
+  const reviewExportBtn = document.getElementById("review-export-btn");
+  const reviewExitBtn = document.getElementById("review-exit-btn");
   const toggleReviewModeBtn = document.getElementById("review-mode-btn");
   const reviewModeControls = document.getElementById("review-mode-controls");
   const imageStatusControls = document.getElementById("image-status-controls");
@@ -1445,6 +1447,12 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         enterReviewMode();
       }
+    });
+  }
+
+  if (reviewExitBtn) {
+    reviewExitBtn.addEventListener("click", () => {
+      if (reviewMode) exitReviewMode();
     });
   }
 

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -129,6 +129,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const reviewExitBtn = document.getElementById("review-exit-btn");
   const toggleReviewModeBtn = document.getElementById("review-mode-btn");
   const reviewModeControls = document.getElementById("review-mode-controls");
+  const reviewModeActions = document.getElementById("review-mode-actions");
   const imageStatusControls = document.getElementById("image-status-controls");
 
   function updateHelpTooltipForMode(mode) {
@@ -195,6 +196,7 @@ document.addEventListener("DOMContentLoaded", () => {
     reviewHistoryIndex = -1;
     updateHelpTooltipForMode("review");
     utils.showElement(reviewModeControls, "flex");
+    utils.showElement(reviewModeActions, "flex");
     utils.hideElement(imageStatusControls);
     if (toggleReviewModeBtn) {
       toggleReviewModeBtn.textContent = "Exit Review";
@@ -218,6 +220,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function exitReviewMode() {
     reviewMode = false;
     utils.hideElement(reviewModeControls);
+    utils.hideElement(reviewModeActions);
     utils.showElement(imageStatusControls, "flex");
     if (toggleReviewModeBtn) {
       toggleReviewModeBtn.textContent = "Start Review";

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -283,6 +283,14 @@
                                 <button id="edit-save-btn" class="text-btn">Save</button>
                                 <button id="edit-cancel-btn" class="text-btn">Cancel</button>
                             </div>
+                            <div id="review-mode-controls" class="review-mode-controls" style="display:none;">
+                                <button id="review-prev-btn" title="Go to previous reviewed image">Prev</button>
+                                <button id="review-skip-btn">Skip</button>
+                                <button id="review-approve-btn">Approve</button>
+                                <button id="review-reject-btn">Reject</button>
+                                <button id="review-export-btn">Export</button>
+                                <button id="review-exit-btn">Exit Review</button>
+                            </div>
                         </div>
                         
                         <!-- Right Column (40%) - Opacity Controls -->
@@ -338,12 +346,6 @@
                             <span class="switch-slider"></span>
                             <span class="switch-label-text">Ready</span>
                         </label>
-                    </div>
-                    <div id="review-mode-controls" class="review-mode-controls" style="display:none;">
-                        <button id="review-prev-btn" title="Go to previous reviewed image">Prev</button>
-                        <button id="review-skip-btn">Skip</button>
-                        <button id="review-approve-btn">Approve</button>
-                        <button id="review-reject-btn">Reject</button>
                     </div>
                 </div>
             </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -310,6 +310,17 @@
                             </div>
                         </div>
                     </div>
+                    <div id="edit-toolbar" class="edit-toolbar" style="display:none;">
+                        <div class="edit-tools">
+                            <button id="edit-brush-btn" class="text-btn">Brush</button>
+                            <button id="edit-eraser-btn" class="text-btn">Eraser</button>
+                            <label>Size <input type="range" id="edit-brush-size" min="1" max="50" value="10"></label>
+                        </div>
+                        <div class="edit-actions">
+                            <button id="edit-save-btn" class="text-btn">Save</button>
+                            <button id="edit-cancel-btn" class="text-btn">Cancel</button>
+                        </div>
+                    </div>
                 </div>
                 <div id="layer-view-section" class="layer-view-section">
                     <button id="add-empty-layer-btn" title="Create empty layer">+</button>
@@ -354,6 +365,7 @@
     <script src="{{ url_for('static', path='js/projectHandler.js') }}"></script> <!-- Project management UI -->
     <script src="{{ url_for('static', path='js/imagePoolHandler.js') }}"></script> <!-- Image gallery/navigation UI -->
     <script src="{{ url_for('static', path='js/layerViewController.js') }}"></script> <!-- Layer view management -->
+    <script src="{{ url_for('static', path='js/editModeController.js') }}"></script>
     <script src="{{ url_for('static', path='js/exportDialog.js') }}"></script>
     <script src="{{ url_for('static', path='js/main.js') }}"></script> <!-- Main application orchestrator -->
 </body>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -261,6 +261,10 @@
                                 <button id="edit-brush-btn" class="text-btn">Brush</button>
                                 <label>Size <input type="range" id="edit-brush-size" min="1" max="50" value="10"></label>
                             </div>
+                            <div id="review-mode-actions" class="review-mode-actions" style="display:none;">
+                                <button id="review-export-btn">Export</button>
+                                <button id="review-exit-btn">Exit Review</button>
+                            </div>
                         </div>
 
                         <!-- Middle Column (20%) - Button Columns -->
@@ -288,8 +292,6 @@
                                 <button id="review-skip-btn">Skip</button>
                                 <button id="review-approve-btn">Approve</button>
                                 <button id="review-reject-btn">Reject</button>
-                                <button id="review-export-btn">Export</button>
-                                <button id="review-exit-btn">Exit Review</button>
                             </div>
                         </div>
                         

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -256,21 +256,32 @@
                         <!-- Left Column (40%) - Mask Toggle Container -->
                         <div class="toolbar-col-1 toolbar-col">
                             <div id="mask-toggle-container" class="mask-toggle-container"></div>
+                            <div id="edit-tools" class="edit-tools" style="display:none;">
+                                <button id="edit-brush-btn" class="text-btn">Brush</button>
+                                <button id="edit-eraser-btn" class="text-btn">Eraser</button>
+                                <label>Size <input type="range" id="edit-brush-size" min="1" max="50" value="10"></label>
+                            </div>
                         </div>
-                        
+
                         <!-- Middle Column (20%) - Button Columns -->
                         <div class="toolbar-col-2 toolbar-col left-controls">
-                            <div class="canvas-toolbar-button-column">
-                                <button id="commit-masks-btn" class="text-btn" title="Add the current predictions to the Layer View">Add</button>
-                                <button id="clear-inputs-btn" class="text-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear</button>
+                            <div id="creation-actions" class="creation-actions">
+                                <div class="canvas-toolbar-button-column">
+                                    <button id="commit-masks-btn" class="text-btn" title="Add the current predictions to the Layer View">Add</button>
+                                    <button id="clear-inputs-btn" class="text-btn" title="Clear points, boxes, and drawn masks from the canvas">Clear</button>
+                                </div>
+                                <div class="canvas-toolbar-button-column">
+                                    <button id="open-auto-mask-overlay" class="icon-btn" title="Automatic mask generation">
+                                        <span class="icon">🪄</span><span class="sr-only">AutoMask</span>
+                                    </button>
+                                    <button id="save-canvas-png-btn" class="icon-btn" title="Download a PNG preview of the current canvas with overlays">
+                                        <span class="icon">💾</span><span class="sr-only">Save PNG</span>
+                                    </button>
+                                </div>
                             </div>
-                            <div class="canvas-toolbar-button-column">
-                                <button id="open-auto-mask-overlay" class="icon-btn" title="Automatic mask generation">
-                                    <span class="icon">🪄</span><span class="sr-only">AutoMask</span>
-                                </button>
-                                <button id="save-canvas-png-btn" class="icon-btn" title="Download a PNG preview of the current canvas with overlays">
-                                    <span class="icon">💾</span><span class="sr-only">Save PNG</span>
-                                </button>
+                            <div id="edit-actions" class="edit-actions" style="display:none;">
+                                <button id="edit-save-btn" class="text-btn">Save</button>
+                                <button id="edit-cancel-btn" class="text-btn">Cancel</button>
                             </div>
                         </div>
                         
@@ -308,17 +319,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div id="edit-toolbar" class="edit-toolbar" style="display:none;">
-                        <div class="edit-tools">
-                            <button id="edit-brush-btn" class="text-btn">Brush</button>
-                            <button id="edit-eraser-btn" class="text-btn">Eraser</button>
-                            <label>Size <input type="range" id="edit-brush-size" min="1" max="50" value="10"></label>
-                        </div>
-                        <div class="edit-actions">
-                            <button id="edit-save-btn" class="text-btn">Save</button>
-                            <button id="edit-cancel-btn" class="text-btn">Cancel</button>
                         </div>
                     </div>
                 </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -245,6 +245,7 @@
                         <canvas id="image-canvas"></canvas>
                         <canvas id="prediction-mask-canvas"></canvas>
                         <canvas id="user-input-canvas"></canvas>
+                        <div id="brush-preview" class="brush-preview"></div>
                         <div id="canvas-lock" class="canvas-lock-overlay">
                             <div class="canvas-lock-content">
                                 <div class="spinner"></div>
@@ -258,7 +259,6 @@
                             <div id="mask-toggle-container" class="mask-toggle-container"></div>
                             <div id="edit-tools" class="edit-tools" style="display:none;">
                                 <button id="edit-brush-btn" class="text-btn">Brush</button>
-                                <button id="edit-eraser-btn" class="text-btn">Eraser</button>
                                 <label>Size <input type="range" id="edit-brush-size" min="1" max="50" value="10"></label>
                             </div>
                         </div>

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -59,13 +59,15 @@ It will be updated as new sprints add functionality.
 - **Initial Edit Tools**: Selecting a single layer now activates a toolbar with
   a brush tool (hold Ctrl or right-click to erase) and Save/Cancel buttons. A
   circular preview shows the brush size.
+- **Review Toolbar**: Review mode controls now appear in the canvas toolbar
+  alongside Export and Exit buttons.
 
 ## Partially Implemented / In Progress
 
 - **Edit Mode Tools**: Brush tool with adjustable size integrated into the main
-  canvas toolbar. Hold Ctrl or right-click to erase. Creation actions hide during
-  editing and review. Lasso and advanced actions (grow, shrink, smooth, invert,
-  undo/redo) remain to be implemented.
+  canvas toolbar. Cursor preview is centred correctly and right-dragging keeps
+  erasing. Creation actions hide during editing and review. Lasso and advanced
+  actions (grow, shrink, smooth, invert, undo/redo) remain to be implemented.
 
 ## Planned Tasks (Priority Order)
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -57,14 +57,15 @@ It will be updated as new sprints add functionality.
 - **Layer Data Schema**: Mask records now use dedicated columns (`class_label`, `status`, `display_color`, `source_metadata`, `updated_at`).
 - **Active Image State**: `main.js` now maintains a full `ActiveImageState` object including `creation` and `edit` sections. New `/api/project/<id>/image/<hash>/state` endpoints keep this state in sync with the backend.
 - **Initial Edit Tools**: Selecting a single layer now activates a toolbar with
-  brush and eraser tools and Save/Cancel buttons.
+  a brush tool (hold Ctrl or right-click to erase) and Save/Cancel buttons. A
+  circular preview shows the brush size.
 
 ## Partially Implemented / In Progress
 
-- **Edit Mode Tools**: Brush/Eraser with size control integrated into the main
-  canvas toolbar. Creation actions hide during editing and review. Lasso and
-  advanced actions (grow, shrink, smooth, invert, undo/redo) remain to be
-  implemented.
+- **Edit Mode Tools**: Brush tool with adjustable size integrated into the main
+  canvas toolbar. Hold Ctrl or right-click to erase. Creation actions hide during
+  editing and review. Lasso and advanced actions (grow, shrink, smooth, invert,
+  undo/redo) remain to be implemented.
 
 ## Planned Tasks (Priority Order)
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -56,11 +56,14 @@ It will be updated as new sprints add functionality.
 - **Review Mode**: Added controls to cycle through images marked `ready_for_review` with Approve/Reject/Skip actions and a history-aware **Prev** button.
 - **Layer Data Schema**: Mask records now use dedicated columns (`class_label`, `status`, `display_color`, `source_metadata`, `updated_at`).
 - **Active Image State**: `main.js` now maintains a full `ActiveImageState` object including `creation` and `edit` sections. New `/api/project/<id>/image/<hash>/state` endpoints keep this state in sync with the backend.
+- **Initial Edit Tools**: Selecting a single layer now activates a toolbar with
+  brush and eraser tools and Save/Cancel buttons.
 
 ## Partially Implemented / In Progress
 
-- **Edit Mode Tools**: Selecting a layer only displays its mask; brush/eraser,
-  lasso, and other edit tools have not been implemented.
+- **Edit Mode Tools**: Basic brush and eraser implemented when a single layer is
+  selected. Lasso and advanced actions (grow, shrink, smooth, invert, undo/redo)
+  remain to be implemented.
 
 ## Planned Tasks (Priority Order)
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -60,14 +60,15 @@ It will be updated as new sprints add functionality.
   a brush tool (hold Ctrl or right-click to erase) and Save/Cancel buttons. A
   circular preview shows the brush size.
 - **Review Toolbar**: Review mode controls now appear in the canvas toolbar
-  alongside Export and Exit buttons.
+  with Export and Exit buttons placed in the first column for better spacing.
 
 ## Partially Implemented / In Progress
 
 - **Edit Mode Tools**: Brush tool with adjustable size integrated into the main
-  canvas toolbar. Cursor preview is centred correctly and right-dragging keeps
-  erasing. Creation actions hide during editing and review. Lasso and advanced
-  actions (grow, shrink, smooth, invert, undo/redo) remain to be implemented.
+  canvas toolbar. The brush preview is centred on the cursor and appears above
+  the image while right-dragging keeps erasing. Creation actions hide during
+  editing and review. Lasso and advanced actions (grow, shrink, smooth,
+  invert, undo/redo) remain to be implemented.
 
 ## Planned Tasks (Priority Order)
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -61,9 +61,10 @@ It will be updated as new sprints add functionality.
 
 ## Partially Implemented / In Progress
 
-- **Edit Mode Tools**: Basic brush and eraser implemented when a single layer is
-  selected. Lasso and advanced actions (grow, shrink, smooth, invert, undo/redo)
-  remain to be implemented.
+- **Edit Mode Tools**: Brush/Eraser with size control integrated into the main
+  canvas toolbar. Creation actions hide during editing and review. Lasso and
+  advanced actions (grow, shrink, smooth, invert, undo/redo) remain to be
+  implemented.
 
 ## Planned Tasks (Priority Order)
 

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -30,6 +30,7 @@ project_root/
   │   │   │   │   ├── modelHandler.js     # Handles model selection, loading, status
   │   │   │   │   ├── imagePoolHandler.js # Handles image gallery, navigation, active image logic
   │   │   │   │   ├── stateManager.js     # Keeps track of current frontend state
+  │   │   │   │   ├── editModeController.js # Manages mask editing tools
   │   │   │   │   └── utils.js            # Frontend utility functions (DOM helpers, formatters)
   │   └── assets/                 # Static assets like icons, placeholder images
   │                               # Served from the `/assets` URL path


### PR DESCRIPTION
## Summary
- implement `EditModeController` with brush/eraser and save/cancel actions
- extend `CanvasManager` to support mask editing
- integrate edit toolbar in HTML/CSS
- wire up editing events in `main.js`
- document new module and update progress log

## Testing
- `black --version`
- `black app/frontend/static/js/editModeController.js app/frontend/static/js/main.js app/frontend/static/js/canvasController.js` *(fails: Cannot parse JavaScript)*

------
https://chatgpt.com/codex/tasks/task_e_68558973c6488320a8cde9d596c3d008