### PR TITLE
Fix mask edit persistence

### DIFF
--- a/app/backend/db_manager.py
+++ b/app/backend/db_manager.py
@@ -793,6 +793,8 @@ def update_mask_layer_basic(
     class_label: Optional[str] = None,
     display_color: Optional[str] = None,
     visible: Optional[bool] = None,
+    mask_data_rle: Optional[Any] = None,
+    status: Optional[str] = None,
 ) -> None:
     """Update simple editable fields for a mask layer."""
     conn = get_db_connection(project_id)
@@ -811,6 +813,18 @@ def update_mask_layer_basic(
     if visible is not None:
         updates.append("visible = ?")
         params.append(1 if visible else 0)
+    if mask_data_rle is not None:
+        updates.append("mask_data_rle = ?")
+        params.append(
+            json.dumps(mask_data_rle)
+            if isinstance(mask_data_rle, (dict, list))
+            else mask_data_rle
+        )
+    if status is not None:
+        updates.append("layer_type = ?")
+        params.append(status)
+        updates.append("status = ?")
+        params.append(status)
     if not updates:
         conn.close()
         return

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -802,6 +802,8 @@ def update_mask_layer_basic(
     class_label: Optional[str] = None,
     display_color: Optional[str] = None,
     visible: Optional[bool] = None,
+    mask_data_rle: Optional[Any] = None,
+    status: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Update editable attributes of a layer and return success."""
     db_manager.update_mask_layer_basic(
@@ -811,6 +813,8 @@ def update_mask_layer_basic(
         class_label=class_label,
         display_color=display_color,
         visible=visible,
+        mask_data_rle=mask_data_rle,
+        status=status,
     )
     return {"success": True, "message": "Layer updated."}
 

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -653,6 +653,8 @@ async def api_update_mask_layer(
     class_label = payload.get("class_label")
     display_color = payload.get("display_color")
     visible = payload.get("visible")
+    mask_data_rle = payload.get("mask_data_rle")
+    status = payload.get("status")
     result = await run_in_threadpool(
         project_logic.update_mask_layer_basic,
         project_id,
@@ -662,6 +664,8 @@ async def api_update_mask_layer(
         class_label,
         display_color,
         visible,
+        mask_data_rle,
+        status,
     )
     return result
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -41,6 +41,7 @@ It will be updated as new sprints add functionality.
 - **Unified Change Handler**: A new `onImageDataChange()` function synchronizes the layer view, caches and status toggles whenever image or layer data changes.
 - **Inline Layer Editing**: Mask name and label fields accept Enter to save changes without deselecting the text field, and edits trigger the unified change handler.
 - **Layer Persistence**: Editing a mask's name or class now sends an update to the backend so changes are saved in the project database.
+- **Mask Edit Persistence**: Saving edits to a mask now updates its RLE data and status in the database so changes survive reloads.
 - **Color Persistence**: Layer colors are stored in the database, including the randomly assigned color when a layer is first created, and can be updated through the layer view.
 - **Auto Status Updates**: The unified handler automatically downgrades images from `Ready` to `In Progress` when layers change unless explicitly skipped.
 - **Recursion Fix**: Status update events no longer cause infinite loops when UI syncs dispatch further status events.


### PR DESCRIPTION
## Summary
- persist manual mask edits by storing updated RLE and status
- document mask edit persistence in progress log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856664c65d88320bf6792bcbafbc382