### PR TITLE
Add hatched mask rendering

### DIFF
--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -909,10 +909,25 @@ class CanvasManager {
         const [r, g, b, a_int] = this._parseRgbaFromString(colorStr);
         const finalAlpha = Math.round(Math.min(1, Math.max(0, opacity)) * a_int);
 
+        const spacing = 6; // pixel spacing between hatch lines
+        const lineWidth = 2; // hatch line thickness
+
+        const isBorder = (mx, my) => {
+            return (
+                mx === 0 || my === 0 || mx === maskWidth - 1 || my === maskHeight - 1 ||
+                !maskData[my][mx - 1] || !maskData[my][mx + 1] ||
+                !(maskData[my - 1] && maskData[my - 1][mx]) ||
+                !(maskData[my + 1] && maskData[my + 1][mx])
+            );
+        };
+
         for (let y = 0; y < maskHeight; y++) {
             for (let x = 0; x < maskWidth; x++) {
-                if (maskData[y][x]) {
-                    const idx = (y * maskWidth + x) * 4;
+                if (!maskData[y][x]) continue;
+                const idx = (y * maskWidth + x) * 4;
+                const border = isBorder(x, y);
+                const drawPixel = border || ((x + y) % spacing < lineWidth);
+                if (drawPixel) {
                     pixelData[idx] = r;
                     pixelData[idx + 1] = g;
                     pixelData[idx + 2] = b;

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -46,6 +46,7 @@ It will be updated as new sprints add functionality.
 - **Auto Status Updates**: The unified handler automatically downgrades images from `Ready` to `In Progress` when layers change unless explicitly skipped.
 - **Recursion Fix**: Status update events no longer cause infinite loops when UI syncs dispatch further status events.
 - **Canvas Modes**: Implemented Creation and Edit display modes. Creation mode fades existing layers and Edit mode highlights selected layers while fading others. Layer masks use their stored colors.
+- **Hatched Masks**: Creation and layer masks now render with a diagonal hatch pattern in their assigned color and include a thin outline.
 - **Layer Selection Improvements**: Shift-click now supports multi-selection, normal-click deselects the single selected layer, and selections maintain order.
 - **Faded Opacity Constant**: Introduced a constant to control faded layer opacity (33%).
 - **Layer Ordering**: New layers are inserted at the top of the list.

--- a/docs/canvas_specification.md
+++ b/docs/canvas_specification.md
@@ -142,7 +142,8 @@ The canvas system employs a three-layer architecture with independent rendering 
 **Mask Data Processing:**
 * **Input Format:** 2D binary arrays matching original image dimensions
 * **Color Assignment:** Dynamic HSL-based color generation for optimal contrast
-* **Rendering:** Convert binary data to colored ImageData for canvas display
+* **Rendering:** Convert binary data to ImageData and apply a diagonal hatch
+  pattern following the mask color with a thin outline for clarity
 * **Optimization:** Use offscreen canvases for complex compositions
 
 **Toggle System:**
@@ -213,8 +214,9 @@ Response: {
 
 **Mask Composition Process:**
 1. **Preparation:** Create offscreen canvas matching display dimensions
-2. **Pixel Processing:** Convert binary mask to colored ImageData
-3. **Region Rendering:** Apply colors to mask pixels (value === 1)
+2. **Pixel Processing:** Convert binary mask to ImageData
+3. **Region Rendering:** Fill mask regions with a diagonal hatch using the mask
+   color and draw a thin outline for better visibility
 4. **Layer Composition:** Composite individual masks onto prediction layer
 5. **Final Display:** Apply opacity and render to visible canvas
 


### PR DESCRIPTION
## Summary
- render creation and layer masks with diagonal hatch in `canvasController.js`
- describe hatch rendering in `canvas_specification.md`
- record hatch feature in `annotation_workflow_progress.md`

## Testing
- `pytest -q`
- `black --check .` *(fails: would reformat)*

------
https://chatgpt.com/codex/tasks/task_e_6857bb1a82108320aec879fdfcca649e