### PR TITLE
Implement lasso and actions in edit mode

### DIFF
--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -119,6 +119,8 @@ class CanvasManager {
         this.editingLayerId = null;
         this.editingMask = null;
         this.editingColor = '#ff0000';
+        this.editHistory = [];
+        this.editHistoryIndex = -1;
 
         this.interactionState = {
             isDrawingBox: false,
@@ -1113,6 +1115,8 @@ class CanvasManager {
         } else {
             this.editingMask = this._createEmptyMask();
         }
+        this.editHistory = [this.getEditedMask()];
+        this.editHistoryIndex = 0;
         this.drawPredictionMaskLayer();
     }
 
@@ -1131,6 +1135,154 @@ class CanvasManager {
                         this.editingMask[ny][nx] = add ? 1 : 0;
                     }
                 }
+            }
+        }
+        this.drawPredictionMaskLayer();
+    }
+
+    applyLasso(points, add = true) {
+        if (!this.editingMask || !points || points.length < 3) return;
+        const h = this.editingMask.length;
+        const w = this.editingMask[0].length;
+        let minX = w, minY = h, maxX = 0, maxY = 0;
+        points.forEach(p => {
+            if (p.x < minX) minX = Math.floor(p.x);
+            if (p.x > maxX) maxX = Math.ceil(p.x);
+            if (p.y < minY) minY = Math.floor(p.y);
+            if (p.y > maxY) maxY = Math.ceil(p.y);
+        });
+        minX = Math.max(0, minX); minY = Math.max(0, minY);
+        maxX = Math.min(w - 1, maxX); maxY = Math.min(h - 1, maxY);
+        for (let y = minY; y <= maxY; y++) {
+            for (let x = minX; x <= maxX; x++) {
+                if (this._isPointInPolygon({x, y}, points)) {
+                    this.editingMask[y][x] = add ? 1 : 0;
+                }
+            }
+        }
+        this.drawPredictionMaskLayer();
+    }
+
+    drawLassoPreview(points) {
+        if (!this.userCtx || !this.offscreenUserCtx) return;
+        this.offscreenUserCtx.clearRect(0, 0, this.offscreenUserCanvas.width, this.offscreenUserCanvas.height);
+        if (points && points.length > 0) {
+            this.offscreenUserCtx.beginPath();
+            const first = this._originalToDisplayCoords(points[0].x, points[0].y);
+            this.offscreenUserCtx.moveTo(first.x, first.y);
+            for (let i = 1; i < points.length; i++) {
+                const p = this._originalToDisplayCoords(points[i].x, points[i].y);
+                this.offscreenUserCtx.lineTo(p.x, p.y);
+            }
+            this.offscreenUserCtx.strokeStyle = 'rgba(255,223,0,0.95)';
+            this.offscreenUserCtx.lineWidth = Math.max(1, 2 * this.displayScale);
+            this.offscreenUserCtx.stroke();
+        }
+        this.userCtx.clearRect(0, 0, this.userInputCanvas.width, this.userInputCanvas.height);
+        this.userCtx.drawImage(this.offscreenUserCanvas, 0, 0);
+    }
+
+    clearLassoPreview() {
+        if (!this.userCtx) return;
+        this.userCtx.clearRect(0, 0, this.userInputCanvas.width, this.userInputCanvas.height);
+    }
+
+    commitHistoryStep() {
+        if (!this.editingMask) return;
+        if (this.editHistoryIndex < this.editHistory.length - 1) {
+            this.editHistory = this.editHistory.slice(0, this.editHistoryIndex + 1);
+        }
+        this.editHistory.push(this.getEditedMask());
+        this.editHistoryIndex = this.editHistory.length - 1;
+    }
+
+    undoEdit() {
+        if (this.editHistoryIndex > 0) {
+            this.editHistoryIndex -= 1;
+            const mask = this.editHistory[this.editHistoryIndex];
+            this.editingMask = mask.map(r => [...r]);
+            this.drawPredictionMaskLayer();
+        }
+    }
+
+    redoEdit() {
+        if (this.editHistoryIndex < this.editHistory.length - 1) {
+            this.editHistoryIndex += 1;
+            const mask = this.editHistory[this.editHistoryIndex];
+            this.editingMask = mask.map(r => [...r]);
+            this.drawPredictionMaskLayer();
+        }
+    }
+
+    growEditingMask() {
+        if (!this.editingMask) return;
+        const h = this.editingMask.length; const w = this.editingMask[0].length;
+        const newMask = this._createEmptyMask();
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                if (this.editingMask[y][x]) {
+                    for (let j = -1; j <= 1; j++) {
+                        for (let i = -1; i <= 1; i++) {
+                            const nx = x + i; const ny = y + j;
+                            if (nx >=0 && ny >=0 && nx < w && ny < h) newMask[ny][nx] = 1;
+                        }
+                    }
+                }
+            }
+        }
+        this.editingMask = newMask;
+        this.drawPredictionMaskLayer();
+    }
+
+    shrinkEditingMask() {
+        if (!this.editingMask) return;
+        const h = this.editingMask.length; const w = this.editingMask[0].length;
+        const newMask = this._createEmptyMask();
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                let all = true;
+                for (let j = -1; j <= 1; j++) {
+                    for (let i = -1; i <= 1; i++) {
+                        const nx = x + i; const ny = y + j;
+                        if (nx < 0 || ny < 0 || nx >= w || ny >= h || !this.editingMask[ny][nx]) {
+                            all = false; break;
+                        }
+                    }
+                    if (!all) break;
+                }
+                newMask[y][x] = all ? 1 : 0;
+            }
+        }
+        this.editingMask = newMask;
+        this.drawPredictionMaskLayer();
+    }
+
+    smoothEditingMask() {
+        if (!this.editingMask) return;
+        const h = this.editingMask.length; const w = this.editingMask[0].length;
+        const newMask = this._createEmptyMask();
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                let count = 0;
+                for (let j = -1; j <= 1; j++) {
+                    for (let i = -1; i <= 1; i++) {
+                        const nx = x + i; const ny = y + j;
+                        if (nx >= 0 && ny >= 0 && nx < w && ny < h && this.editingMask[ny][nx]) count++;
+                    }
+                }
+                newMask[y][x] = count >= 5 ? 1 : 0;
+            }
+        }
+        this.editingMask = newMask;
+        this.drawPredictionMaskLayer();
+    }
+
+    invertEditingMask() {
+        if (!this.editingMask) return;
+        const h = this.editingMask.length; const w = this.editingMask[0].length;
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                this.editingMask[y][x] = this.editingMask[y][x] ? 0 : 1;
             }
         }
         this.drawPredictionMaskLayer();

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -14,6 +14,9 @@ class EditModeController {
         this.activeLayer = null;
         this.brushSize = 10;
         this.isDrawing = false;
+        this.currentTool = 'brush'; // 'brush' or 'lasso'
+        this.lassoPoints = [];
+        this.lassoAdd = true;
         this.initElements();
         this.attachListeners();
     }
@@ -22,7 +25,14 @@ class EditModeController {
         this.toolsContainer = document.getElementById('edit-tools');
         this.actionsContainer = document.getElementById('edit-actions');
         this.brushBtn = document.getElementById('edit-brush-btn');
+        this.lassoBtn = document.getElementById('edit-lasso-btn');
         this.brushSizeInput = document.getElementById('edit-brush-size');
+        this.growBtn = document.getElementById('edit-grow-btn');
+        this.shrinkBtn = document.getElementById('edit-shrink-btn');
+        this.smoothBtn = document.getElementById('edit-smooth-btn');
+        this.invertBtn = document.getElementById('edit-invert-btn');
+        this.undoBtn = document.getElementById('edit-undo-btn');
+        this.redoBtn = document.getElementById('edit-redo-btn');
         this.saveBtn = document.getElementById('edit-save-btn');
         this.cancelBtn = document.getElementById('edit-cancel-btn');
         this.previewEl = document.getElementById('brush-preview');
@@ -33,6 +43,14 @@ class EditModeController {
             this.brushSize = parseInt(this.brushSizeInput.value, 10) || 1;
             this.updatePreviewSize();
         });
+        if (this.brushBtn) this.brushBtn.addEventListener('click', () => this.selectTool('brush'));
+        if (this.lassoBtn) this.lassoBtn.addEventListener('click', () => this.selectTool('lasso'));
+        if (this.growBtn) this.growBtn.addEventListener('click', () => this.actionGrow());
+        if (this.shrinkBtn) this.shrinkBtn.addEventListener('click', () => this.actionShrink());
+        if (this.smoothBtn) this.smoothBtn.addEventListener('click', () => this.actionSmooth());
+        if (this.invertBtn) this.invertBtn.addEventListener('click', () => this.actionInvert());
+        if (this.undoBtn) this.undoBtn.addEventListener('click', () => this.actionUndo());
+        if (this.redoBtn) this.redoBtn.addEventListener('click', () => this.actionRedo());
         if (this.saveBtn) this.saveBtn.addEventListener('click', () => this.save());
         if (this.cancelBtn) this.cancelBtn.addEventListener('click', () => this.cancel());
         const canvas = this.canvasManager.userInputCanvas;
@@ -58,6 +76,7 @@ class EditModeController {
         this.activeLayer = layer;
         this.canvasManager.startMaskEdit(layer.layerId, layer.maskData, layer.displayColor);
         this.showControls(true);
+        this.selectTool('brush');
         this.updatePreviewSize();
     }
 
@@ -66,6 +85,7 @@ class EditModeController {
         this.showControls(false);
         this.canvasManager.finishMaskEdit();
         if (this.previewEl) this.previewEl.style.display = 'none';
+        this.canvasManager.clearLassoPreview();
     }
 
     showControls(show) {
@@ -77,31 +97,51 @@ class EditModeController {
     onMouseDown(e) {
         if (!this.activeLayer) return;
         this.isDrawing = true;
-        if (this.previewEl) {
+        if (this.currentTool === 'brush' && this.previewEl) {
             this.previewEl.style.position = 'fixed';
             this.previewEl.style.left = `${e.clientX}px`;
             this.previewEl.style.top = `${e.clientY}px`;
             this.previewEl.style.pointerEvents = 'none';
         }
-        this.applyBrush(e);
+        if (this.currentTool === 'brush') {
+            this.applyBrush(e);
+        } else if (this.currentTool === 'lasso') {
+            this.lassoPoints = [this.canvasManager._displayToOriginalCoords(e.clientX, e.clientY)];
+            const rightHeld = e.buttons === 2 || e.button === 2;
+            this.lassoAdd = !(rightHeld || e.ctrlKey);
+            this.canvasManager.drawLassoPreview(this.lassoPoints);
+        }
         e.preventDefault();
     }
 
 
     onMouseMove(e) {
         if (!this.activeLayer) return;
-        if (this.previewEl) {
+        if (this.currentTool === 'brush' && this.previewEl) {
             this.previewEl.style.position = 'fixed';
             this.previewEl.style.left = `${e.clientX}px`;
             this.previewEl.style.top = `${e.clientY}px`;
             this.previewEl.style.pointerEvents = 'none';
         }
         if (!this.isDrawing) return;
-        this.applyBrush(e);
+        if (this.currentTool === 'brush') {
+            this.applyBrush(e);
+        } else if (this.currentTool === 'lasso') {
+            this.lassoPoints.push(this.canvasManager._displayToOriginalCoords(e.clientX, e.clientY));
+            this.canvasManager.drawLassoPreview(this.lassoPoints);
+        }
         e.preventDefault();
     }
 
     onMouseUp() {
+        if (this.currentTool === 'lasso' && this.isDrawing && this.lassoPoints.length > 2) {
+            this.canvasManager.applyLasso(this.lassoPoints, this.lassoAdd);
+            this.canvasManager.commitHistoryStep();
+            this.canvasManager.clearLassoPreview();
+            this.lassoPoints = [];
+        } else if (this.currentTool === 'brush' && this.isDrawing) {
+            this.canvasManager.commitHistoryStep();
+        }
         this.isDrawing = false;
     }
 
@@ -110,6 +150,42 @@ class EditModeController {
         const rightHeld = e.buttons === 2 || e.button === 2;
         const add = !(rightHeld || e.ctrlKey);
         this.canvasManager.applyBrush(coords.x, coords.y, this.brushSize, add);
+    }
+
+    selectTool(tool) {
+        this.currentTool = tool;
+        if (this.brushBtn) this.brushBtn.classList.toggle('active', tool === 'brush');
+        if (this.lassoBtn) this.lassoBtn.classList.toggle('active', tool === 'lasso');
+        if (this.previewEl) this.previewEl.style.display = tool === 'brush' && this.activeLayer ? 'block' : 'none';
+        this.canvasManager.clearLassoPreview();
+    }
+
+    actionGrow() {
+        this.canvasManager.growEditingMask();
+        this.canvasManager.commitHistoryStep();
+    }
+
+    actionShrink() {
+        this.canvasManager.shrinkEditingMask();
+        this.canvasManager.commitHistoryStep();
+    }
+
+    actionSmooth() {
+        this.canvasManager.smoothEditingMask();
+        this.canvasManager.commitHistoryStep();
+    }
+
+    actionInvert() {
+        this.canvasManager.invertEditingMask();
+        this.canvasManager.commitHistoryStep();
+    }
+
+    actionUndo() {
+        this.canvasManager.undoEdit();
+    }
+
+    actionRedo() {
+        this.canvasManager.redoEdit();
     }
 
     save() {

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -260,6 +260,7 @@
                             <div id="edit-tools" class="edit-tools" style="display:none;">
                                 <button id="edit-brush-btn" class="text-btn">Brush</button>
                                 <label>Size <input type="range" id="edit-brush-size" min="1" max="50" value="10"></label>
+                                <button id="edit-lasso-btn" class="text-btn">Lasso</button>
                             </div>
                             <div id="review-mode-actions" class="review-mode-actions" style="display:none;">
                                 <button id="review-export-btn">Export</button>
@@ -284,6 +285,12 @@
                                 </div>
                             </div>
                             <div id="edit-actions" class="edit-actions" style="display:none;">
+                                <button id="edit-grow-btn" class="text-btn">Grow</button>
+                                <button id="edit-shrink-btn" class="text-btn">Shrink</button>
+                                <button id="edit-smooth-btn" class="text-btn">Smooth</button>
+                                <button id="edit-invert-btn" class="text-btn">Invert</button>
+                                <button id="edit-undo-btn" class="text-btn">Undo</button>
+                                <button id="edit-redo-btn" class="text-btn">Redo</button>
                                 <button id="edit-save-btn" class="text-btn">Save</button>
                                 <button id="edit-cancel-btn" class="text-btn">Cancel</button>
                             </div>

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -59,17 +59,11 @@ It will be updated as new sprints add functionality.
 - **Initial Edit Tools**: Selecting a single layer now activates a toolbar with
   a brush tool (hold Ctrl or right-click to erase) and Save/Cancel buttons. A
   circular preview shows the brush size.
+- **Advanced Edit Tools**: Lasso add/remove, grow, shrink, smooth, invert and
+  undo/redo actions complete the edit toolbar.
 - **Review Toolbar**: Review mode controls now appear in the canvas toolbar
   with Export and Exit buttons placed in the first column for better spacing.
 - **Canvas Zoom & Pan**: Mouse wheel zooms up to 4× the image resolution and middle-drag pans for precise placement. Zoom remains centered on the cursor, pan ends on middle-button release and zoom-pan updates trigger an event for tool UI. Zoom resets when a new image loads.
-
-## Partially Implemented / In Progress
-
-- **Edit Mode Tools**: Brush tool with adjustable size integrated into the main
-  canvas toolbar. The brush preview is centred on the cursor and appears above
-  the image while right-dragging keeps erasing. Creation actions hide during
-  editing and review. Lasso and advanced actions (grow, shrink, smooth,
-  invert, undo/redo) remain to be implemented.
 
 ## Planned Tasks (Priority Order)
 


### PR DESCRIPTION
## Summary
- expose full edit toolbar in `index.html`
- add tool selection and action handling to `editModeController.js`
- add lasso editing, morph ops and history to `canvasController.js`
- update progress docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857cff0e1cc8320a0478177aded6207