### PR TITLE
Support multiple tags per layer

### DIFF
--- a/app/backend/export_logic.py
+++ b/app/backend/export_logic.py
@@ -384,6 +384,8 @@ def prepare_export_data(
                     layer_tags = [layer_tags]
             rle_obj = layer["mask_data_rle"]
             bbox, area = _convert_rle_to_bbox_and_area(rle_obj)
+            if area <= 0:
+                continue
             for tag in layer_tags or [None]:
                 category_id = category_map.get(tag, default_cat)
                 if category_id is None:

--- a/app/backend/export_logic.py
+++ b/app/backend/export_logic.py
@@ -177,7 +177,7 @@ def calculate_export_stats(
         if visibility_mode == "and":
             include = layer.get("visible", True)
             if class_labels:
-                layer_tags = layer.get("class_label") or []
+                layer_tags = layer.get("class_labels") or []
                 if isinstance(layer_tags, str):
                     try:
                         layer_tags = json.loads(layer_tags)
@@ -187,7 +187,7 @@ def calculate_export_stats(
         elif visibility_mode == "or":
             include = layer.get("visible", True)
             if class_labels:
-                layer_tags = layer.get("class_label") or []
+                layer_tags = layer.get("class_labels") or []
                 if isinstance(layer_tags, str):
                     try:
                         layer_tags = json.loads(layer_tags)
@@ -197,7 +197,7 @@ def calculate_export_stats(
                     include = True
         else:  # none
             if class_labels:
-                layer_tags = layer.get("class_label") or []
+                layer_tags = layer.get("class_labels") or []
                 if isinstance(layer_tags, str):
                     try:
                         layer_tags = json.loads(layer_tags)
@@ -211,7 +211,7 @@ def calculate_export_stats(
 
     label_counts: Dict[str, int] = {}
     for layer in all_layers:
-        labels = layer.get("class_label") or []
+        labels = layer.get("class_labels") or []
         if isinstance(labels, str):
             try:
                 labels = json.loads(labels)
@@ -291,7 +291,7 @@ def prepare_export_data(
         filtered_layers: List[Dict[str, Any]] = []
         for layer in all_layers:
             include = True
-            layer_tags = layer.get("class_label") or []
+            layer_tags = layer.get("class_labels") or []
             if isinstance(layer_tags, str):
                 try:
                     layer_tags = json.loads(layer_tags)
@@ -328,7 +328,7 @@ def prepare_export_data(
 
         tag_set: Set[str] = set()
         for layer in all_layers:
-            tags = layer.get("class_label") or []
+            tags = layer.get("class_labels") or []
             if isinstance(tags, str):
                 try:
                     tags = json.loads(tags)
@@ -376,7 +376,7 @@ def prepare_export_data(
             img_id = image_id_map.get(layer["image_hash_ref"])
             if not img_id:
                 continue
-            layer_tags = layer.get("class_label") or []
+            layer_tags = layer.get("class_labels") or []
             if isinstance(layer_tags, str):
                 try:
                     layer_tags = json.loads(layer_tags)

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -848,7 +848,7 @@ def get_image_state(project_id: str, image_hash: str) -> Dict[str, Any]:
                 mask_rle = json.loads(mask_rle)
             except json.JSONDecodeError:
                 pass
-        cls_val = m.get("class_label") or meta.get("class_label")
+        cls_val = m.get("class_labels") or meta.get("class_labels")
         if isinstance(cls_val, str):
             try:
                 cls_val = json.loads(cls_val)

--- a/app/backend/project_logic.py
+++ b/app/backend/project_logic.py
@@ -799,7 +799,7 @@ def update_mask_layer_basic(
     image_hash: str,
     layer_id: str,
     name: Optional[str] = None,
-    class_label: Optional[str] = None,
+    class_labels: Optional[List[str]] = None,
     display_color: Optional[str] = None,
     visible: Optional[bool] = None,
     mask_data_rle: Optional[Any] = None,
@@ -810,7 +810,7 @@ def update_mask_layer_basic(
         project_id,
         layer_id,
         name=name,
-        class_label=class_label,
+        class_labels=class_labels,
         display_color=display_color,
         visible=visible,
         mask_data_rle=mask_data_rle,
@@ -848,11 +848,17 @@ def get_image_state(project_id: str, image_hash: str) -> Dict[str, Any]:
                 mask_rle = json.loads(mask_rle)
             except json.JSONDecodeError:
                 pass
+        cls_val = m.get("class_label") or meta.get("class_label")
+        if isinstance(cls_val, str):
+            try:
+                cls_val = json.loads(cls_val)
+            except json.JSONDecodeError:
+                cls_val = [cls_val]
         layers.append(
             {
                 "layerId": m["layer_id"],
                 "name": m.get("name"),
-                "classLabel": m.get("class_label") or meta.get("class_label"),
+                "classLabels": cls_val or [],
                 "status": m.get("status") or m.get("layer_type"),
                 "visible": bool(m.get("visible", True)),
                 "displayColor": m.get("display_color") or meta.get("display_color"),
@@ -887,15 +893,15 @@ def update_image_state(
         if not lid:
             continue
         name = layer.get("name")
-        class_label = layer.get("classLabel")
+        class_labels = layer.get("classLabels")
         display_color = layer.get("displayColor")
         visible = layer.get("visible")
-        if any(v is not None for v in (name, class_label, display_color, visible)):
+        if any(v is not None for v in (name, class_labels, display_color, visible)):
             db_manager.update_mask_layer_basic(
                 project_id,
                 lid,
                 name=name,
-                class_label=class_label,
+                class_labels=class_labels,
                 display_color=display_color,
                 visible=visible,
             )

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -650,7 +650,7 @@ async def api_update_mask_layer(
             status_code=403, detail="Operation only allowed on the active project"
         )
     name = payload.get("name")
-    class_label = payload.get("class_label")
+    class_labels = payload.get("class_labels")
     display_color = payload.get("display_color")
     visible = payload.get("visible")
     mask_data_rle = payload.get("mask_data_rle")
@@ -661,7 +661,7 @@ async def api_update_mask_layer(
         image_hash,
         layer_id,
         name,
-        class_label,
+        class_labels,
         display_color,
         visible,
         mask_data_rle,

--- a/app/backend/server.py
+++ b/app/backend/server.py
@@ -626,6 +626,26 @@ async def api_get_image_masks(
     return {"success": True, "masks": mask_layers}
 
 
+@app.post("/api/project/{project_id}/images/{image_hash}/layers")
+async def api_create_empty_layer(project_id: str, image_hash: str, payload: dict):
+    if project_id != get_active_project_id():
+        raise HTTPException(
+            status_code=403, detail="Operation only allowed on the active project"
+        )
+    name = payload.get("name")
+    class_labels = payload.get("class_labels")
+    display_color = payload.get("display_color")
+    result = await run_in_threadpool(
+        project_logic.create_empty_layer,
+        project_id,
+        image_hash,
+        name,
+        class_labels,
+        display_color,
+    )
+    return result
+
+
 @app.delete("/api/project/{project_id}/images/{image_hash}/layers/{layer_id}")
 async def api_delete_mask_layer(project_id: str, image_hash: str, layer_id: str):
     if project_id != get_active_project_id():

--- a/app/frontend/static/js/apiClient.js
+++ b/app/frontend/static/js/apiClient.js
@@ -334,6 +334,14 @@ class APIClient {
     );
   }
 
+  async createEmptyLayer(projectId, imageHash, payload) {
+    return this._request(
+      `/project/${projectId}/images/${imageHash}/layers`,
+      "POST",
+      payload,
+    );
+  }
+
   // --- Export Endpoints ---
   async requestExport(projectId, payload) {
     // payload: { format, export_schema, filters: { image_statuses, layer_statuses } }

--- a/app/frontend/static/js/layerViewController.js
+++ b/app/frontend/static/js/layerViewController.js
@@ -141,9 +141,9 @@ class LayerViewController {
             const classInput = document.createElement('input');
             classInput.className = 'layer-class-input';
             classInput.type = 'text';
-            classInput.placeholder = 'label';
-            classInput.value = layer.classLabel || '';
-            classInput.title = 'Class label';
+            classInput.placeholder = 'tags';
+            classInput.value = Array.isArray(layer.classLabels) ? layer.classLabels.join(', ') : '';
+            classInput.title = 'Layer tags, comma separated';
             classInput.addEventListener('mousedown', (e) => e.stopPropagation());
             classInput.addEventListener('click', (e) => e.stopPropagation());
             classInput.addEventListener('keydown', (e) => {
@@ -155,8 +155,11 @@ class LayerViewController {
             });
             classInput.addEventListener('change', (e) => {
                 e.stopPropagation();
-                layer.classLabel = classInput.value.trim();
-                this.Utils.dispatchCustomEvent('layer-class-changed', { layerId: layer.layerId, classLabel: layer.classLabel });
+                layer.classLabels = classInput.value
+                    .split(',')
+                    .map((t) => t.trim())
+                    .filter((t) => t);
+                this.Utils.dispatchCustomEvent('layer-tags-changed', { layerId: layer.layerId, classLabels: layer.classLabels });
             });
 
             const statusTag = document.createElement('span');

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -573,8 +573,8 @@ document.addEventListener("DOMContentLoaded", () => {
         return {
           layerId: m.layer_id || `layer_${idx}`,
           name: m.name || `Mask ${idx + 1}`,
-          classLabels: Array.isArray(m.class_label) ? m.class_label :
-            (m.class_label ? [m.class_label] : []),
+          classLabels: Array.isArray(m.class_labels) ? m.class_labels :
+            (m.class_labels ? [m.class_labels] : []),
           status: m.status || "prediction",
           visible: m.visible !== false,
           displayColor: m.display_color || utils.getRandomHexColor(),

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -277,7 +277,7 @@ document.addEventListener("DOMContentLoaded", () => {
       layers: activeImageState.layers.map((l) => ({
         layerId: l.layerId,
         name: l.name,
-        classLabel: l.classLabel,
+        classLabels: Array.isArray(l.classLabels) ? l.classLabels : [],
         status: l.status,
         displayColor: l.displayColor,
         visible: l.visible,
@@ -534,7 +534,7 @@ document.addEventListener("DOMContentLoaded", () => {
         return {
           layerId: m.layerId,
           name: m.name || `Mask ${idx + 1}`,
-          classLabel: m.classLabel || "",
+          classLabels: Array.isArray(m.classLabels) ? m.classLabels : [],
           status: m.status || "prediction",
           visible: m.visible !== false,
           displayColor: m.displayColor || utils.getRandomHexColor(),
@@ -573,7 +573,8 @@ document.addEventListener("DOMContentLoaded", () => {
         return {
           layerId: m.layer_id || `layer_${idx}`,
           name: m.name || `Mask ${idx + 1}`,
-          classLabel: m.class_label || "",
+          classLabels: Array.isArray(m.class_label) ? m.class_label :
+            (m.class_label ? [m.class_label] : []),
           status: m.status || "prediction",
           visible: m.visible !== false,
           displayColor: m.display_color || utils.getRandomHexColor(),
@@ -704,7 +705,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const newLayer = {
         layerId: crypto.randomUUID(),
         name: `Mask ${activeImageState.layers.length + 1}`,
-        classLabel: "",
+        classLabels: [],
         status: "edited",
         visible: true,
         displayColor: utils.getRandomHexColor(),
@@ -1066,7 +1067,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const newLayers = selected.map((mask, idx) => ({
         layerId: ids[idx] || crypto.randomUUID(),
         name: masksToCommit[idx].name,
-        classLabel: "",
+        classLabels: [],
         status: "edited",
         visible: true,
         displayColor: masksToCommit[idx].display_color,
@@ -1188,19 +1189,21 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  document.addEventListener("layer-class-changed", (event) => {
+  document.addEventListener("layer-tags-changed", (event) => {
     if (!activeImageState) return;
     const layer = activeImageState.layers.find(
       (l) => l.layerId === event.detail.layerId,
     );
     if (layer) {
-      layer.classLabel = event.detail.classLabel || "";
+      layer.classLabels = Array.isArray(event.detail.classLabels)
+        ? event.detail.classLabels
+        : [];
       const pid = stateManager.getActiveProjectId();
       const ih = activeImageState.imageHash;
       if (pid && ih) {
         apiClient
           .updateMaskLayer(pid, ih, layer.layerId, {
-            class_label: layer.classLabel,
+            class_labels: layer.classLabels,
           })
           .catch((err) => {
             uiManager.showGlobalStatus(

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -54,7 +54,7 @@ It will be updated as new sprints add functionality.
 - **Default Mode on Load**: Loading an image now enters Edit mode if layers exist and skips legacy prediction data, preventing stray red masks from appearing.
 - **Legacy Prediction Removal**: Old code paths for restoring saved prediction masks have been deleted. Existing masks always load as layers.
 - **Review Mode**: Added controls to cycle through images marked `ready_for_review` with Approve/Reject/Skip actions and a history-aware **Prev** button.
-- **Layer Data Schema**: Mask records now use dedicated columns (`class_label`, `status`, `display_color`, `source_metadata`, `updated_at`).
+- **Layer Data Schema**: Mask records now use dedicated columns (`class_labels`, `status`, `display_color`, `source_metadata`, `updated_at`).
 - **Active Image State**: `main.js` now maintains a full `ActiveImageState` object including `creation` and `edit` sections. New `/api/project/<id>/image/<hash>/state` endpoints keep this state in sync with the backend.
 - **Initial Edit Tools**: Selecting a single layer now activates a toolbar with
   a brush tool (hold Ctrl or right-click to erase) and Save/Cancel buttons. A
@@ -73,8 +73,8 @@ It will be updated as new sprints add functionality.
 
 1. ~~**Database and API Refactor**~~
    - ~~Migrate the `Images` and `Mask_Layers` tables to the new schema with image
-     statuses (`unprocessed`, `in_progress`, `ready_for_review`, `approved`,
-     `rejected`, `skip`) and per-layer fields (`class_label`, `status`,
+    statuses (`unprocessed`, `in_progress`, `ready_for_review`, `approved`,
+     `rejected`, `skip`) and per-layer fields (`class_labels`, `status`,
      `display_color`, `source_metadata`, `updated_at`).~~
    - ~~Adjust CRUD helpers and update existing endpoints to read/write the new
      schema.~~

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -56,6 +56,7 @@ It will be updated as new sprints add functionality.
 - **Review Mode**: Added controls to cycle through images marked `ready_for_review` with Approve/Reject/Skip actions and a history-aware **Prev** button.
 - **Layer Data Schema**: Mask records now use dedicated columns (`class_labels`, `status`, `display_color`, `source_metadata`, `updated_at`).
 - **Active Image State**: `main.js` now maintains a full `ActiveImageState` object including `creation` and `edit` sections. New `/api/project/<id>/image/<hash>/state` endpoints keep this state in sync with the backend.
+- **Empty Layer Persistence**: Creating an empty layer now immediately saves it to the database so manual edits are not lost on refresh.
 - **Initial Edit Tools**: Selecting a single layer now activates a toolbar with
   a brush tool (hold Ctrl or right-click to erase) and Save/Cancel buttons. A
   circular preview shows the brush size.

--- a/docs/annotation_workflow_specification.md
+++ b/docs/annotation_workflow_specification.md
@@ -398,6 +398,11 @@ for layer in all_layers:
         annotation_id_counter += 1
 ```
 
+Since the COCO specification allows only a single category per annotation,
+the loop above adds a separate annotation entry for each tag in a layer's
+`class_labels` list. These entries share the same segmentation data but have
+different `category_id` values.
+
 #### 3.3.3. Recommended Library for RLE Handling
 
 The placeholder `_convert_rle_to_bbox_and_area` function is insufficient and error-prone. To ensure compatibility with the COCO standard and accurate calculations, it is **highly recommended** to integrate `pycocotools` into the export logic (already part of installed project dependencies.)


### PR DESCRIPTION
## Summary
- allow each mask layer to store multiple tags in `class_labels`
- update database helpers and server API for new tag list field
- adjust export logic to output one annotation per tag
- modify frontend to handle comma separated tag lists
- update docs on new `class_labels` format

## Testing
- `black app/backend/db_manager.py app/backend/project_logic.py app/backend/export_logic.py app/backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_685998d685048320bd76d9fe306728f9