### PR TITLE
feat: Implement Tagify Widget for layer tags

### DIFF
--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -1108,16 +1108,16 @@ input[type="file"]#image-upload {
   flex: 1 1 25px;
   min-width: 25px;
   padding: 2px 4px;
-  font-size: 13px;
+  font-size: 11px;
 }
 .layer-class-input {
-  flex: 2 1 25px;
+  flex: 4 1 25px;
   min-width: 30px;
   padding: 0px 0px;
   font-size: 11px;
 }
 .layer-item .tagify {
-  flex: 2 1 25px;
+  flex: 4 1 25px;
   min-width: 30px;
   display: inline-flex;
   align-items: center;

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -1119,6 +1119,12 @@ input[type="file"]#image-upload {
 .layer-item .tagify {
   flex: 2 1 25px;
   min-width: 30px;
+  display: inline-flex;
+  align-items: center;
+}
+.layer-item .tagify__input {
+  flex: 1 0 80px;
+  min-width: 80px;
 }
 .layer-status-tag {
   font-size: 11px;
@@ -1386,7 +1392,7 @@ input[type="file"]#image-upload {
     background: #F3F3F3;
     /* --tag-bg: #F3F3F3; */
     margin: .2em;
-    font-size: .85em;
+    font-size: .75em;
     color: black;
     transition: 0s;
 }

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -149,16 +149,6 @@ header p {
   background-color: #adb5bd;
   cursor: not-allowed;
 }
-.layer-view-section {
-  width: auto;
-  flex: 1;
-  min-width: 0;
-  min-height: 0;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
 
 .config-section h2,
 .image-section h2,
@@ -1059,11 +1049,13 @@ input[type="file"]#image-upload {
 /* Layer View */
 .layer-view-section {
   background: white;
-  padding: 20px;
+  padding: 8px 4px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
+  width: auto;
+  flex: 1;
   min-width: 0;
   min-height: 0;
   height: 100%;
@@ -1087,11 +1079,19 @@ input[type="file"]#image-upload {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 2px 0;
+  padding: 12px 4px;
   flex-wrap: wrap;
+  border-radius: 2px;
+  transition: background-color 0.2s ease;
+}
+.layer-item:hover {
+  background-color: #f8f9fa;
 }
 .layer-item.selected {
   background-color: #f0f4ff;
+}
+.layer-item.selected:hover {
+  background-color: #e6f0ff;
 }
 .layer-vis-toggle {
   border: none;
@@ -1113,7 +1113,7 @@ input[type="file"]#image-upload {
 .layer-class-input {
   flex: 2 1 25px;
   min-width: 30px;
-  padding: 2px 4px;
+  padding: 0px 0px;
   font-size: 11px;
 }
 .layer-item .tagify {
@@ -1121,10 +1121,14 @@ input[type="file"]#image-upload {
   min-width: 30px;
   display: inline-flex;
   align-items: center;
+  padding: 0px 0px;
+  border-radius: 4px;
+  /* border-color: transparent; */
 }
 .layer-item .tagify__input {
-  flex: 1 0 80px;
-  min-width: 80px;
+  flex: 1 0 40px;
+  min-width: 40px;
+
 }
 .layer-status-tag {
   font-size: 11px;

--- a/app/frontend/static/css/style.css
+++ b/app/frontend/static/css/style.css
@@ -1116,6 +1116,10 @@ input[type="file"]#image-upload {
   padding: 2px 4px;
   font-size: 11px;
 }
+.layer-item .tagify {
+  flex: 2 1 25px;
+  min-width: 30px;
+}
 .layer-status-tag {
   font-size: 11px;
   padding: 2px 4px;

--- a/app/frontend/static/js/layerViewController.js
+++ b/app/frontend/static/js/layerViewController.js
@@ -16,6 +16,9 @@ class LayerViewController {
 
     setProjectTags(tags) {
         this.allProjectTags = Array.isArray(tags) ? [...tags] : [];
+        if (this.layers.length > 0) {
+            this.render();
+        }
     }
 
     setLayers(layers) {
@@ -150,6 +153,7 @@ class LayerViewController {
             classInput.title = 'Layer tags';
             const initialTags = Array.isArray(layer.classLabels) ? layer.classLabels : [];
             const available = this.allProjectTags.filter(t => !initialTags.includes(t));
+            classInput.value = initialTags.join(',');
 
             const statusTag = document.createElement('span');
             statusTag.className = `layer-status-tag ${layer.status || ''}`;
@@ -181,13 +185,14 @@ class LayerViewController {
 
             const tagify = new Tagify(classInput, {
                 whitelist: available,
-                delimiters: '\n',
+                delimiters: ',',
+                pattern: /[^,]+/,
             });
-            tagify.addTags(initialTags);
             tagify.DOM.scope.addEventListener('mousedown', e => e.stopPropagation());
             tagify.DOM.scope.addEventListener('click', e => e.stopPropagation());
             tagify.on('change', () => {
                 const tags = tagify.value.map(it => it.value);
+                if (JSON.stringify(tags) === JSON.stringify(layer.classLabels || [])) return;
                 layer.classLabels = tags;
                 tagify.settings.whitelist = this.allProjectTags.filter(t => !tags.includes(t));
                 tagify.dropdown.refilter();

--- a/app/frontend/static/js/layerViewController.js
+++ b/app/frontend/static/js/layerViewController.js
@@ -150,20 +150,6 @@ class LayerViewController {
             classInput.title = 'Layer tags';
             const initialTags = Array.isArray(layer.classLabels) ? layer.classLabels : [];
             const available = this.allProjectTags.filter(t => !initialTags.includes(t));
-            const tagify = new Tagify(classInput, {
-                whitelist: available,
-                delimiters: '\n',
-            });
-            tagify.addTags(initialTags);
-            tagify.DOM.scope.addEventListener('mousedown', e => e.stopPropagation());
-            tagify.DOM.scope.addEventListener('click', e => e.stopPropagation());
-            tagify.on('change', () => {
-                const tags = tagify.value.map(it => it.value);
-                layer.classLabels = tags;
-                tagify.settings.whitelist = this.allProjectTags.filter(t => !tags.includes(t));
-                tagify.dropdown.refilter();
-                this.Utils.dispatchCustomEvent('layer-tags-changed', { layerId: layer.layerId, classLabels: tags });
-            });
 
             const statusTag = document.createElement('span');
             statusTag.className = `layer-status-tag ${layer.status || ''}`;
@@ -192,6 +178,21 @@ class LayerViewController {
             li.appendChild(classInput);
             li.appendChild(statusTag);
             li.appendChild(deleteBtn);
+
+            const tagify = new Tagify(classInput, {
+                whitelist: available,
+                delimiters: '\n',
+            });
+            tagify.addTags(initialTags);
+            tagify.DOM.scope.addEventListener('mousedown', e => e.stopPropagation());
+            tagify.DOM.scope.addEventListener('click', e => e.stopPropagation());
+            tagify.on('change', () => {
+                const tags = tagify.value.map(it => it.value);
+                layer.classLabels = tags;
+                tagify.settings.whitelist = this.allProjectTags.filter(t => !tags.includes(t));
+                tagify.dropdown.refilter();
+                this.Utils.dispatchCustomEvent('layer-tags-changed', { layerId: layer.layerId, classLabels: tags });
+            });
             listEl.appendChild(li);
         });
 

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -41,6 +41,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const canvasStateCache = {};
   let imageLayerCache = {};
+  let projectTagList = [];
+  let layerTagDebouncers = {};
 
   // modelHandler.js is a script that self-initializes its DOM listeners.
   // We don't instantiate it as a class here, but we will need its functions if we were to call them.
@@ -343,8 +345,24 @@ document.addEventListener("DOMContentLoaded", () => {
           status: data.active_image.status,
         });
       }
+      await loadProjectLabels();
     } catch (err) {
       console.error("Error restoring session state:", err);
+    }
+  }
+
+  async function loadProjectLabels() {
+    const pid = stateManager.getActiveProjectId();
+    if (!pid) return;
+    try {
+      const data = await apiClient.getProjectLabels(pid);
+      if (Array.isArray(data.labels)) {
+        projectTagList = data.labels;
+        stateManager.setProjectLabels(projectTagList);
+        if (layerViewController) layerViewController.setProjectTags(projectTagList);
+      }
+    } catch (err) {
+      console.error('Failed to fetch project labels', err);
     }
   }
 
@@ -391,6 +409,7 @@ document.addEventListener("DOMContentLoaded", () => {
       applyPostprocessing:
         projectData?.settings?.current_sam_apply_postprocessing === "true",
     });
+    loadProjectLabels();
     updateStatusToggleUI("unprocessed", false);
   });
 
@@ -415,6 +434,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     if (imagePoolHandler) imagePoolHandler.loadAndDisplayImagePool();
     await restoreSessionFromServer();
+    await loadProjectLabels();
     updateStatusToggleUI("unprocessed", false);
   });
 
@@ -1216,16 +1236,24 @@ document.addEventListener("DOMContentLoaded", () => {
       const pid = stateManager.getActiveProjectId();
       const ih = activeImageState.imageHash;
       if (pid && ih) {
-        apiClient
-          .updateMaskLayer(pid, ih, layer.layerId, {
-            class_labels: layer.classLabels,
-          })
-          .catch((err) => {
-            uiManager.showGlobalStatus(
-              `Layer update failed: ${utils.escapeHTML(err.message)}`,
-              "error",
-            );
-          });
+        if (!layerTagDebouncers[layer.layerId]) {
+          layerTagDebouncers[layer.layerId] = utils.debounce(
+            (p, h, lid, payload) => {
+              apiClient
+                .updateMaskLayer(p, h, lid, payload)
+                .catch((err) => {
+                  uiManager.showGlobalStatus(
+                    `Layer update failed: ${utils.escapeHTML(err.message)}`,
+                    "error",
+                  );
+                });
+            },
+            400,
+          );
+        }
+        layerTagDebouncers[layer.layerId](pid, ih, layer.layerId, {
+          class_labels: layer.classLabels,
+        });
       }
       onImageDataChange("layer-modified", { layerId: layer.layerId });
     }

--- a/app/frontend/static/js/stateManager.js
+++ b/app/frontend/static/js/stateManager.js
@@ -33,6 +33,7 @@ class StateManager {
             uiPreferences: {
                 theme: 'light', // Example preference
             },
+            projectLabels: [],
             // Add other global states as needed
         };
         console.log("StateManager initialized with initial state:", this.state);
@@ -101,6 +102,12 @@ class StateManager {
         this.setState('currentLoadedModelInfo', modelInfo);
     }
     getCurrentLoadedModel() { return this.getState('currentLoadedModelInfo'); }
+
+    setProjectLabels(labels) {
+        if (!Array.isArray(labels)) labels = [];
+        this.setState('projectLabels', labels);
+    }
+    getProjectLabels() { return this.getState('projectLabels'); }
 
     // Example for UI preferences
     setTheme(theme) {

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -100,5 +100,6 @@ It will be updated as new sprints add functionality.
 - Improve error handling and autosave of `ActiveImageState` to prevent data
     loss.
 - **Tagify Layer Tags**: Layer tags are edited using the Tagify widget with
-  auto-suggestions from existing project tags.
+  auto-suggestions from existing project tags. Suggestions update when tags
+  change and appear when focusing the tag field.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -96,7 +96,9 @@ It will be updated as new sprints add functionality.
    - ~~Update export and filtering logic to handle the full status lifecycle.~~
 5. **Incremental Enhancements**
    - ~~Persist `display_color` and label information when adding layers.~~
-   - ~~Add update-status dropdown in the annotation view.~~ Implemented as Ready/Skip toggle switches.
-   - Improve error handling and autosave of `ActiveImageState` to prevent data
-     loss.
+- ~~Add update-status dropdown in the annotation view.~~ Implemented as Ready/Skip toggle switches.
+- Improve error handling and autosave of `ActiveImageState` to prevent data
+    loss.
+- **Tagify Layer Tags**: Layer tags are edited using the Tagify widget with
+  auto-suggestions from existing project tags.
 


### PR DESCRIPTION
## Summary
- replace layer tag text input with Tagify widget and add suggestion list
- store project tag list in `StateManager` and fetch via `/labels` API
- debounce tag update API calls per layer
- document Tagify support in progress file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859c2fb2aa4832088d1eebff838321b