### PR TITLE
Improve layer mask editing workflow

### DIFF
--- a/app/frontend/static/css/canvas.css
+++ b/app/frontend/static/css/canvas.css
@@ -266,12 +266,12 @@
 #save-canvas-png-btn:hover:not(:disabled) {
   background-color: #0056b3;
 }
-#commit-masks-btn, #edit-save-btn{
+#commit-masks-btn{
   background-color: #28a745;
   padding: 8px 16px;
   font-size: 15px;
 } /* Green for commit */
-#commit-masks-btn:hover:not(:disabled), #edit-save-btn:hover:not(:disabled) {
+#commit-masks-btn:hover:not(:disabled) {
   background-color: #218838;
 }
 #edit-undo-btn, #edit-redo-btn {
@@ -282,7 +282,7 @@
 }
 
 /* Clear Inputs Button */
-#clear-inputs-btn, #edit-cancel-btn {
+#clear-inputs-btn, #edit-discard-btn {
   background: linear-gradient(135deg, #ff7300, #ffa500);
   border: none;
   padding: 8px 16px;
@@ -293,12 +293,12 @@
   transition: all 0.3s ease;
   box-shadow: 0 2px 4px rgba(255, 140, 0, 0.2);
 }
-#clear-inputs-btn:hover:not(:disabled), #edit-cancel-btn:hover:not(:disabled) {
+#clear-inputs-btn:hover:not(:disabled), #edit-discard-btn:hover:not(:disabled) {
   background: linear-gradient(135deg, #e67e00, #cb7600);
   box-shadow: 0 4px 8px rgba(255, 140, 0, 0.3);
   transform: translateY(-1px);
 }
-#clear-inputs-btn:disabled, #edit-cancel-btn:disabled {
+#clear-inputs-btn:disabled, #edit-discard-btn:disabled {
   background: #ccc;
   color: #888;
   box-shadow: none;
@@ -306,7 +306,7 @@
   cursor: not-allowed;
 }
 
-#clear-inputs-btn #edit-cancel-btn{
+#clear-inputs-btn #edit-discard-btn{
   width: 100%;
   margin-top: 10px;
 }

--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -738,6 +738,14 @@ class CanvasManager {
 
     _handleWheel(e) {
         if (!this.currentImage) return;
+
+        if (this.editingMask && e.ctrlKey) {
+            e.preventDefault();
+            const delta = e.deltaY < 0 ? 1 : -1;
+            this._dispatchEvent('brushSizeScroll', { delta });
+            return;
+        }
+
         e.preventDefault();
 
         const rect = this.userInputCanvas.getBoundingClientRect();

--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -116,9 +116,7 @@ class CanvasManager {
         this.selectedLayerIds = [];
         this.mode = 'edit'; // 'creation', 'edit', 'review'
 
-        this.editingLayerId = null;
-        this.editingMask = null;
-        this.editingColor = '#ff0000';
+        this.editingLayers = {}; // { layerId: { mask, color } }
         this.editHistory = [];
         this.editHistoryIndex = -1;
 
@@ -515,13 +513,10 @@ class CanvasManager {
                 if (this.mode === 'edit' && this.selectedLayerIds.length > 0) {
                     op = this.selectedLayerIds.includes(l.layerId) ? 1.0 : FADED_MASK_OPACITY;
                 }
-                const mask = (this.editingLayerId && l.layerId === this.editingLayerId && this.editingMask)
-                    ? this.editingMask
-                    : l.maskData;
-                const color = (this.editingLayerId && l.layerId === this.editingLayerId)
-                    ? this.editingColor
-                    : l.color;
-                const hatch = !(this.editingLayerId && l.layerId === this.editingLayerId);
+                const isEditing = this.editingLayers.hasOwnProperty(l.layerId);
+                const mask = isEditing ? this.editingLayers[l.layerId].mask : l.maskData;
+                const color = isEditing ? this.editingLayers[l.layerId].color : l.color;
+                const hatch = !isEditing;
                 if (mask) this._drawBinaryMask(mask, color, op, hatch);
             });
         }
@@ -1101,51 +1096,62 @@ class CanvasManager {
         this.drawPredictionMaskLayer();
     }
 
-    startMaskEdit(layerId, maskData, color) {
-        this.editingLayerId = layerId;
-        this.editingColor = color || '#ff0000';
-        if (Array.isArray(maskData) && Array.isArray(maskData[0])) {
-            this.editingMask = maskData.map(r => Array.from(r));
-        } else if (maskData && maskData.counts && maskData.size) {
-            const converted = this.Utils.rleToBinaryMask(
-                maskData,
-                this.originalImageHeight,
-                this.originalImageWidth
-            );
-            this.editingMask = converted || this._createEmptyMask();
-        } else {
-            this.editingMask = this._createEmptyMask();
-        }
-        this.editHistory = [this.getEditedMask()];
+    startMaskEdit(layers) {
+        this.editingLayers = {};
+        if (!Array.isArray(layers)) layers = [];
+        layers.forEach(layer => {
+            let mask;
+            if (Array.isArray(layer.maskData) && Array.isArray(layer.maskData[0])) {
+                mask = layer.maskData.map(r => Array.from(r));
+            } else if (layer.maskData && layer.maskData.counts && layer.maskData.size) {
+                mask = this.Utils.rleToBinaryMask(
+                    layer.maskData,
+                    this.originalImageHeight,
+                    this.originalImageWidth
+                );
+                mask = mask || this._createEmptyMask();
+            } else {
+                mask = this._createEmptyMask();
+            }
+            this.editingLayers[layer.layerId] = { mask, color: layer.displayColor || layer.color || '#ff0000' };
+        });
+        this.editHistory = [this.getEditedMasks()];
         this.editHistoryIndex = 0;
         this.drawPredictionMaskLayer();
     }
 
     applyBrush(x, y, radius, add = true) {
-        if (!this.editingMask) return;
-        const h = this.editingMask.length;
-        const w = this.editingMask[0].length;
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0) return;
         const cx = Math.round(x);
         const cy = Math.round(y);
-        for (let j = -radius; j <= radius; j++) {
-            for (let i = -radius; i <= radius; i++) {
-                if (i*i + j*j <= radius*radius) {
-                    const nx = cx + i;
-                    const ny = cy + j;
-                    if (nx >=0 && ny >=0 && nx < w && ny < h) {
-                        this.editingMask[ny][nx] = add ? 1 : 0;
+        layerIds.forEach(id => {
+            const mask = this.editingLayers[id].mask;
+            const h = mask.length;
+            const w = mask[0].length;
+            for (let j = -radius; j <= radius; j++) {
+                for (let i = -radius; i <= radius; i++) {
+                    if (i * i + j * j <= radius * radius) {
+                        const nx = cx + i;
+                        const ny = cy + j;
+                        if (nx >= 0 && ny >= 0 && nx < w && ny < h) {
+                            mask[ny][nx] = add ? 1 : 0;
+                        }
                     }
                 }
             }
-        }
+        });
         this.drawPredictionMaskLayer();
     }
 
     applyLasso(points, add = true) {
-        if (!this.editingMask || !points || points.length < 3) return;
-        const h = this.editingMask.length;
-        const w = this.editingMask[0].length;
-        let minX = w, minY = h, maxX = 0, maxY = 0;
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0 || !points || points.length < 3) return;
+        let minX, minY, maxX, maxY;
+        const anyMask = this.editingLayers[layerIds[0]].mask;
+        const h = anyMask.length;
+        const w = anyMask[0].length;
+        minX = w; minY = h; maxX = 0; maxY = 0;
         points.forEach(p => {
             if (p.x < minX) minX = Math.floor(p.x);
             if (p.x > maxX) maxX = Math.ceil(p.x);
@@ -1154,13 +1160,16 @@ class CanvasManager {
         });
         minX = Math.max(0, minX); minY = Math.max(0, minY);
         maxX = Math.min(w - 1, maxX); maxY = Math.min(h - 1, maxY);
-        for (let y = minY; y <= maxY; y++) {
-            for (let x = minX; x <= maxX; x++) {
-                if (this._isPointInPolygon({x, y}, points)) {
-                    this.editingMask[y][x] = add ? 1 : 0;
+        layerIds.forEach(id => {
+            const mask = this.editingLayers[id].mask;
+            for (let y = minY; y <= maxY; y++) {
+                for (let x = minX; x <= maxX; x++) {
+                    if (this._isPointInPolygon({x, y}, points)) {
+                        mask[y][x] = add ? 1 : 0;
+                    }
                 }
             }
-        }
+        });
         this.drawPredictionMaskLayer();
     }
 
@@ -1189,19 +1198,25 @@ class CanvasManager {
     }
 
     commitHistoryStep() {
-        if (!this.editingMask) return;
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0) return;
         if (this.editHistoryIndex < this.editHistory.length - 1) {
             this.editHistory = this.editHistory.slice(0, this.editHistoryIndex + 1);
         }
-        this.editHistory.push(this.getEditedMask());
+        this.editHistory.push(this.getEditedMasks());
         this.editHistoryIndex = this.editHistory.length - 1;
     }
 
     undoEdit() {
         if (this.editHistoryIndex > 0) {
             this.editHistoryIndex -= 1;
-            const mask = this.editHistory[this.editHistoryIndex];
-            this.editingMask = mask.map(r => [...r]);
+            const snapshot = this.editHistory[this.editHistoryIndex];
+            for (const id of Object.keys(snapshot)) {
+                if (this.editingLayers[id]) {
+                    const mask = snapshot[id];
+                    this.editingLayers[id].mask = mask.map(r => [...r]);
+                }
+            }
             this.drawPredictionMaskLayer();
         }
     }
@@ -1209,41 +1224,60 @@ class CanvasManager {
     redoEdit() {
         if (this.editHistoryIndex < this.editHistory.length - 1) {
             this.editHistoryIndex += 1;
-            const mask = this.editHistory[this.editHistoryIndex];
-            this.editingMask = mask.map(r => [...r]);
+            const snapshot = this.editHistory[this.editHistoryIndex];
+            for (const id of Object.keys(snapshot)) {
+                if (this.editingLayers[id]) {
+                    const mask = snapshot[id];
+                    this.editingLayers[id].mask = mask.map(r => [...r]);
+                }
+            }
             this.drawPredictionMaskLayer();
         }
     }
 
     growEditingMask() {
-        if (!this.editingMask) return;
-        this.editingMask = this._dilateMask(this.editingMask);
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0) return;
+        layerIds.forEach(id => {
+            this.editingLayers[id].mask = this._dilateMask(this.editingLayers[id].mask);
+        });
         this.drawPredictionMaskLayer();
     }
 
     shrinkEditingMask() {
-        if (!this.editingMask) return;
-        this.editingMask = this._erodeMask(this.editingMask);
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0) return;
+        layerIds.forEach(id => {
+            this.editingLayers[id].mask = this._erodeMask(this.editingLayers[id].mask);
+        });
         this.drawPredictionMaskLayer();
     }
 
     smoothEditingMask() {
-        if (!this.editingMask) return;
-        let mask = this._dilateMask(this._erodeMask(this.editingMask));
-        mask = this._erodeMask(this._dilateMask(mask));
-        mask = this._smoothMask(mask);
-        this.editingMask = mask;
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0) return;
+        layerIds.forEach(id => {
+            let mask = this.editingLayers[id].mask;
+            mask = this._dilateMask(this._erodeMask(mask));
+            mask = this._erodeMask(this._dilateMask(mask));
+            mask = this._smoothMask(mask);
+            this.editingLayers[id].mask = mask;
+        });
         this.drawPredictionMaskLayer();
     }
 
     invertEditingMask() {
-        if (!this.editingMask) return;
-        const h = this.editingMask.length; const w = this.editingMask[0].length;
-        for (let y = 0; y < h; y++) {
-            for (let x = 0; x < w; x++) {
-                this.editingMask[y][x] = this.editingMask[y][x] ? 0 : 1;
+        const layerIds = Object.keys(this.editingLayers);
+        if (layerIds.length === 0) return;
+        layerIds.forEach(id => {
+            const mask = this.editingLayers[id].mask;
+            const h = mask.length; const w = mask[0].length;
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    mask[y][x] = mask[y][x] ? 0 : 1;
+                }
             }
-        }
+        });
         this.drawPredictionMaskLayer();
     }
 
@@ -1304,13 +1338,18 @@ class CanvasManager {
         return out;
     }
 
-    getEditedMask() {
-        return this.editingMask ? this.editingMask.map(r => [...r]) : null;
+    getEditedMasks() {
+        const out = {};
+        for (const [id, obj] of Object.entries(this.editingLayers)) {
+            out[id] = obj.mask.map(r => [...r]);
+        }
+        return out;
     }
 
     finishMaskEdit() {
-        this.editingLayerId = null;
-        this.editingMask = null;
+        this.editingLayers = {};
+        this.editHistory = [];
+        this.editHistoryIndex = -1;
         this.drawPredictionMaskLayer();
     }
 

--- a/app/frontend/static/js/canvasController.js
+++ b/app/frontend/static/js/canvasController.js
@@ -521,7 +521,8 @@ class CanvasManager {
                 const color = (this.editingLayerId && l.layerId === this.editingLayerId)
                     ? this.editingColor
                     : l.color;
-                if (mask) this._drawBinaryMask(mask, color, op);
+                const hatch = !(this.editingLayerId && l.layerId === this.editingLayerId);
+                if (mask) this._drawBinaryMask(mask, color, op, hatch);
             });
         }
 
@@ -893,7 +894,7 @@ class CanvasManager {
         }
     }
 
-    _drawBinaryMask(maskData, colorStr, opacity = 1.0) {
+    _drawBinaryMask(maskData, colorStr, opacity = 1.0, hatch = true) {
         if (!maskData || !maskData.length || !maskData[0].length) return;
         const maskHeight = maskData.length;
         const maskWidth = maskData[0].length;
@@ -909,7 +910,7 @@ class CanvasManager {
         const [r, g, b, a_int] = this._parseRgbaFromString(colorStr);
         const finalAlpha = Math.round(Math.min(1, Math.max(0, opacity)) * a_int);
 
-        const spacing = 6; // pixel spacing between hatch lines
+        const spacing = 4; // pixel spacing between hatch lines (tighter pattern)
         const lineWidth = 2; // hatch line thickness
 
         const isBorder = (mx, my) => {
@@ -926,7 +927,7 @@ class CanvasManager {
                 if (!maskData[y][x]) continue;
                 const idx = (y * maskWidth + x) * 4;
                 const border = isBorder(x, y);
-                const drawPixel = border || ((x + y) % spacing < lineWidth);
+                const drawPixel = border || !hatch || ((x + y) % spacing < lineWidth);
                 if (drawPixel) {
                     pixelData[idx] = r;
                     pixelData[idx + 1] = g;

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -11,7 +11,7 @@ class EditModeController {
         this.stateManager = stateManager;
         this.apiClient = apiClient;
         this.utils = utils;
-        this.activeLayers = [];
+        this.activeLayer = null;
         this.brushSize = 10;
         this.isDrawing = false;
         this.currentTool = 'brush'; // 'brush' or 'lasso'
@@ -69,17 +69,17 @@ class EditModeController {
         this.previewEl.style.height = `${r}px`;
     }
 
-    beginEdit(layers) {
-        if (!Array.isArray(layers) || layers.length === 0) return;
-        this.activeLayers = layers;
-        this.canvasManager.startMaskEdit(layers);
+    beginEdit(layer) {
+        if (!layer) return;
+        this.activeLayer = layer;
+        this.canvasManager.startMaskEdit(layer.layerId, layer.maskData, layer.displayColor);
         this.showControls(true);
         this.selectTool('brush');
         this.updatePreviewSize();
     }
 
     endEdit() {
-        this.activeLayers = [];
+        this.activeLayer = null;
         this.showControls(false);
         this.canvasManager.finishMaskEdit();
         if (this.previewEl) this.previewEl.style.display = 'none';
@@ -93,7 +93,7 @@ class EditModeController {
     }
 
     onMouseDown(e) {
-        if (!this.activeLayers || this.activeLayers.length === 0) return;
+        if (!this.activeLayer) return;
         this.isDrawing = true;
         if (this.currentTool === 'brush' && this.previewEl) {
             this.previewEl.style.position = 'fixed';
@@ -114,7 +114,7 @@ class EditModeController {
 
 
     onMouseMove(e) {
-        if (!this.activeLayers || this.activeLayers.length === 0) return;
+        if (!this.activeLayer) return;
         if (this.currentTool === 'brush' && this.previewEl) {
             this.previewEl.style.position = 'fixed';
             this.previewEl.style.left = `${e.clientX}px`;
@@ -154,7 +154,7 @@ class EditModeController {
         this.currentTool = tool;
         if (this.brushBtn) this.brushBtn.classList.toggle('active', tool === 'brush');
         if (this.lassoBtn) this.lassoBtn.classList.toggle('active', tool === 'lasso');
-        if (this.previewEl) this.previewEl.style.display = tool === 'brush' && this.activeLayers && this.activeLayers.length > 0 ? 'block' : 'none';
+        if (this.previewEl) this.previewEl.style.display = tool === 'brush' && this.activeLayer ? 'block' : 'none';
         this.canvasManager.clearLassoPreview();
     }
 

--- a/app/frontend/static/js/editModeController.js
+++ b/app/frontend/static/js/editModeController.js
@@ -60,6 +60,9 @@ class EditModeController {
             canvas.addEventListener('contextmenu', (e) => e.preventDefault());
         }
         this.canvasManager.addEventListener('zoom-pan-changed', () => this.updatePreviewSize());
+        document.addEventListener('canvas-brushSizeScroll', (e) => {
+            this.adjustBrushSize(e.detail.delta);
+        });
     }
 
     updatePreviewSize() {
@@ -67,6 +70,15 @@ class EditModeController {
         const r = this.brushSize * this.canvasManager.getZoomedDisplayScale() * 2;
         this.previewEl.style.width = `${r}px`;
         this.previewEl.style.height = `${r}px`;
+    }
+
+    adjustBrushSize(delta) {
+        this.brushSize += delta;
+        if (this.brushSize < 1) this.brushSize = 1;
+        const max = this.brushSizeInput ? parseInt(this.brushSizeInput.max, 10) : 50;
+        if (this.brushSize > max) this.brushSize = max;
+        if (this.brushSizeInput) this.brushSizeInput.value = this.brushSize;
+        this.updatePreviewSize();
     }
 
     beginEdit(layer) {

--- a/app/frontend/static/js/layerViewController.js
+++ b/app/frontend/static/js/layerViewController.js
@@ -10,6 +10,7 @@ class LayerViewController {
         this.stateManager = stateManager;
         this.layers = [];
         this.selectedLayerIds = [];
+        this.lastSelectedLayerId = null;
         this.allProjectTags = [];
         this.tagifyInstances = {};
         this.Utils = window.Utils || { dispatchCustomEvent: (n,d)=>document.dispatchEvent(new CustomEvent(n,{detail:d})) };
@@ -51,12 +52,14 @@ class LayerViewController {
 
     setSelectedLayers(layerIds) {
         this.selectedLayerIds = Array.isArray(layerIds) ? [...layerIds] : [];
+        this.lastSelectedLayerId = this.selectedLayerIds.length > 0 ? this.selectedLayerIds[this.selectedLayerIds.length - 1] : null;
         this.render();
     }
 
     clearSelection() {
         if (this.selectedLayerIds.length > 0) {
             this.selectedLayerIds = [];
+            this.lastSelectedLayerId = null;
             this.Utils.dispatchCustomEvent('layers-selected', { layerIds: [] });
             this.render();
         }
@@ -67,14 +70,20 @@ class LayerViewController {
             const idx = this.selectedLayerIds.indexOf(layerId);
             if (idx !== -1) {
                 this.selectedLayerIds.splice(idx, 1);
+                if (layerId === this.lastSelectedLayerId) {
+                    this.lastSelectedLayerId = this.selectedLayerIds[this.selectedLayerIds.length - 1] || null;
+                }
             } else {
                 this.selectedLayerIds.push(layerId);
+                this.lastSelectedLayerId = layerId;
             }
         } else {
             if (this.selectedLayerIds.length === 1 && this.selectedLayerIds[0] === layerId) {
                 this.selectedLayerIds = [];
+                this.lastSelectedLayerId = null;
             } else {
                 this.selectedLayerIds = [layerId];
+                this.lastSelectedLayerId = layerId;
             }
         }
         this.Utils.dispatchCustomEvent('layers-selected', { layerIds: [...this.selectedLayerIds] });
@@ -88,6 +97,9 @@ class LayerViewController {
             const selIdx = this.selectedLayerIds.indexOf(layerId);
             if (selIdx !== -1) {
                 this.selectedLayerIds.splice(selIdx, 1);
+                if (layerId === this.lastSelectedLayerId) {
+                    this.lastSelectedLayerId = this.selectedLayerIds[this.selectedLayerIds.length - 1] || null;
+                }
                 this.Utils.dispatchCustomEvent('layers-selected', { layerIds: [...this.selectedLayerIds] });
             }
             this.Utils.dispatchCustomEvent('layer-deleted', { layerId });

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -855,14 +855,12 @@ document.addEventListener("DOMContentLoaded", () => {
         .filter(Boolean);
       if (others.length === 0) return;
       others.forEach((o) => {
-        if (o.maskData && activeLayer.maskData) {
-          for (let y = 0; y < activeLayer.maskData.length; y++) {
-            for (let x = 0; x < activeLayer.maskData[0].length; x++) {
-              activeLayer.maskData[y][x] = activeLayer.maskData[y][x] || o.maskData[y][x];
-            }
+        if (o.maskData) {
+          if (activeLayer.maskData) {
+            utils.unionBinaryMasks(activeLayer.maskData, o.maskData);
+          } else {
+            activeLayer.maskData = JSON.parse(JSON.stringify(o.maskData));
           }
-        } else if (o.maskData && !activeLayer.maskData) {
-          activeLayer.maskData = JSON.parse(JSON.stringify(o.maskData));
         }
         (o.classLabels || []).forEach((t) => {
           if (!activeLayer.classLabels.includes(t)) activeLayer.classLabels.push(t);

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -888,6 +888,15 @@ document.addEventListener("DOMContentLoaded", () => {
       layerViewController.setSelectedLayers([activeLayerId]);
       canvasManager.setLayers(activeImageState.layers);
       canvasManager.setMode("edit", [activeLayerId]);
+      if (editModeController) {
+        const layer = activeImageState.layers.find(
+          (l) => l.layerId === activeLayerId,
+        );
+        if (layer) editModeController.beginEdit(layer);
+      }
+      utils.dispatchCustomEvent("layers-selected", {
+        layerIds: [activeLayerId],
+      });
       updateLayerUtilityButtons();
     });
   }

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -168,6 +168,17 @@ document.addEventListener("DOMContentLoaded", () => {
   let suppressStatusChangeEvents = false;
   let selectedLayerIds = [];
   let activeLayerId = null;
+
+  function updateLayerUtilityButtons() {
+    if (duplicateLayerBtn) {
+      duplicateLayerBtn.disabled = !activeLayerId;
+    }
+    if (mergeLayersBtn) {
+      mergeLayersBtn.disabled = !(
+        activeLayerId && Array.isArray(selectedLayerIds) && selectedLayerIds.length > 1
+      );
+    }
+  }
   async function autoSaveCurrentEdits() {
     if (!activeImageState || !editModeController || !editModeController.activeLayer) return;
     const mask = canvasManager.getEditedMask();
@@ -220,6 +231,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   updateStatusToggleUI("unprocessed", false);
+  updateLayerUtilityButtons();
   updateHelpTooltipForMode("creation");
 
   function enterReviewMode() {
@@ -779,6 +791,7 @@ document.addEventListener("DOMContentLoaded", () => {
           onImageDataChange("layer-added", { layerIds: [newLayer.layerId] });
           canvasManager.clearAllCanvasInputs(false);
           canvasManager.setMode("edit");
+          updateLayerUtilityButtons();
         }
       } catch (err) {
         console.error("Failed to create empty layer", err);
@@ -825,6 +838,7 @@ document.addEventListener("DOMContentLoaded", () => {
       } catch (err) {
         uiManager.showGlobalStatus(`Duplicate failed: ${utils.escapeHTML(err.message)}`, "error");
       }
+      updateLayerUtilityButtons();
     });
   }
 
@@ -862,6 +876,7 @@ document.addEventListener("DOMContentLoaded", () => {
           status: "edited",
         });
       }
+      onImageDataChange("layer-modified", { layerId: activeLayer.layerId });
       for (const o of others) {
         activeImageState.layers = activeImageState.layers.filter((l) => l.layerId !== o.layerId);
         try {
@@ -873,6 +888,7 @@ document.addEventListener("DOMContentLoaded", () => {
       layerViewController.setSelectedLayers([activeLayerId]);
       canvasManager.setLayers(activeImageState.layers);
       canvasManager.setMode("edit", [activeLayerId]);
+      updateLayerUtilityButtons();
     });
   }
 
@@ -1296,6 +1312,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!reviewMode) updateHelpTooltipForMode("creation");
       }
     }
+    updateLayerUtilityButtons();
   });
 
   document.addEventListener("layer-deleted", async (event) => {
@@ -1489,6 +1506,7 @@ document.addEventListener("DOMContentLoaded", () => {
       editModeController.endEdit();
     }
     canvasManager.setMode("creation");
+    updateLayerUtilityButtons();
   });
 
   document.addEventListener("active-image-cleared", async () => {
@@ -1499,6 +1517,7 @@ document.addEventListener("DOMContentLoaded", () => {
     activeImageState = null;
     canvasManager.setMode("creation");
     updateStatusToggleUI("unprocessed", false);
+    updateLayerUtilityButtons();
   });
 
   document.addEventListener("image-status-updated", (event) => {

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -898,6 +898,8 @@ document.addEventListener("DOMContentLoaded", () => {
         layerIds: [activeLayerId],
       });
       updateLayerUtilityButtons();
+      canvasManager.setLayers(activeImageState.layers);
+      canvasManager.drawPredictionMaskLayer();
     });
   }
 

--- a/app/frontend/static/js/main.js
+++ b/app/frontend/static/js/main.js
@@ -482,7 +482,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // == ImagePoolHandler Events ==
   document.addEventListener("active-image-set", async (event) => {
-    const {
+  const {
       imageHash,
       filename,
       width,
@@ -491,6 +491,9 @@ document.addEventListener("DOMContentLoaded", () => {
       existingMasks,
       status,
     } = event.detail;
+    canvasManager.clearAllCanvasInputs(true);
+    canvasManager.setManualPredictions(null);
+    canvasManager.setAutomaskPredictions(null);
     uiManager.showGlobalStatus(
       `Loading image '${utils.escapeHTML(filename)}' for annotation...`,
       "loading",
@@ -1125,7 +1128,7 @@ document.addEventListener("DOMContentLoaded", () => {
     canvasManager.clearAllCanvasInputs(false);
     canvasManager.setManualPredictions(null);
     canvasManager.setAutomaskPredictions(null);
-    canvasManager.setMode("edit");
+    canvasManager.setMode("creation");
   }
 
   if (commitMasksBtn && !commitMasksBtn.dataset.listenerAttached) {

--- a/app/frontend/static/js/utils.js
+++ b/app/frontend/static/js/utils.js
@@ -243,6 +243,24 @@ const Utils = {
         }
         counts.push(count);
         return { counts, size: [height, width] };
+    },
+
+    /**
+     * Combine two binary masks by union. Modifies and returns `base`.
+     * @param {Array<Array<number>>} base - 2D binary mask array to merge into.
+     * @param {Array<Array<number>>} other - 2D binary mask array to merge from.
+     * @returns {Array<Array<number>>} base mask after union.
+     */
+    unionBinaryMasks: (base, other) => {
+        if (!base || !other) return base;
+        const h = Math.min(base.length, other.length);
+        const w = Math.min(base[0].length, other[0].length);
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                base[y][x] = base[y][x] || other[y][x] ? 1 : 0;
+            }
+        }
+        return base;
     }
 };
 

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -297,8 +297,7 @@
                             <div id="edit-actions" class="edit-actions" style="display:none;">
                                 <div class="canvas-toolbar-button-column">
                                     <div class="canvas-toolbar-button-row">
-                                        <button id="edit-save-btn" class="text-btn" title="Save edits">Save</button>
-                                        <button id="edit-cancel-btn" class="text-btn" title="Cancel edits">Cancel</button>
+                                        <button id="edit-discard-btn" class="text-btn" title="Discard edits">Discard</button>
                                     </div>
                                     <div class="canvas-toolbar-button-row">
                                         <button id="edit-undo-btn" class="icon-btn" title="Undo"><span class="icon">⟲</span><span class="sr-only">Undo</span></button>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -352,6 +352,8 @@
                 </div>
                 <div id="layer-view-section" class="layer-view-section">
                     <button id="add-empty-layer-btn" title="Create empty layer">+</button>
+                    <button id="duplicate-layer-btn" class="text-btn" title="Duplicate layer">⧉</button>
+                    <button id="merge-layers-btn" class="text-btn" title="Merge selected">Merge</button>
                     <div id="layer-view-container">
                         <p><em>No layers yet. Use "Add to Layers".</em></p>
                     </div>

--- a/app/frontend/templates/index.html
+++ b/app/frontend/templates/index.html
@@ -352,12 +352,12 @@
                 </div>
                 <div id="layer-view-section" class="layer-view-section">
                     <button id="add-empty-layer-btn" title="Create empty layer">+</button>
-                    <button id="duplicate-layer-btn" class="text-btn" title="Duplicate layer">⧉</button>
-                    <button id="merge-layers-btn" class="text-btn" title="Merge selected">Merge</button>
                     <div id="layer-view-container">
                         <p><em>No layers yet. Use "Add to Layers".</em></p>
                     </div>
                     <div id="image-status-controls" class="image-status-controls">
+                        <button id="duplicate-layer-btn" class="text-btn" title="Duplicate layer">⧉</button>
+                        <button id="merge-layers-btn" class="text-btn" title="Merge selected">Merge</button>
                         <label class="switch-control">
                             <input type="checkbox" id="skip-switch">
                             <span class="switch-slider"></span>

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -107,5 +107,6 @@ It will be updated as new sprints add functionality.
     `Discard` button to revert changes.
   - **Layer Utilities**: Duplicate and Merge buttons appear next to the Skip/Ready toggles and refresh the canvas immediately after merging.
   - **Merge Redraw Fix**: The canvas now refreshes after merging layers so merged masks appear immediately.
-  - **Merge Union**: Overlapping regions from merged layers are combined so no pixel is covered by multiple masks in the resulting layer.
+- **Merge Union**: Overlapping regions from merged layers are combined so no pixel is covered by multiple masks in the resulting layer.
+- **Brush Size Shortcut**: Holding Ctrl while scrolling over the canvas now adjusts the brush size instead of zooming.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -99,7 +99,10 @@ It will be updated as new sprints add functionality.
 - ~~Add update-status dropdown in the annotation view.~~ Implemented as Ready/Skip toggle switches.
 - Improve error handling and autosave of `ActiveImageState` to prevent data
     loss.
-- **Tagify Layer Tags**: Layer tags are edited using the Tagify widget with
-  auto-suggestions from existing project tags. Suggestions update when tags
-  change and appear when focusing the tag field.
+  - **Tagify Layer Tags**: Layer tags are edited using the Tagify widget with
+    auto-suggestions from existing project tags. Suggestions update when tags
+    change and appear when focusing the tag field.
+  - **Auto-Saving Edits**: Mask edits are saved automatically when changing
+    layer selection or images. The edit toolbar now features a single
+    `Discard` button to revert changes.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -105,4 +105,5 @@ It will be updated as new sprints add functionality.
   - **Auto-Saving Edits**: Mask edits are saved automatically when changing
     layer selection or images. The edit toolbar now features a single
     `Discard` button to revert changes.
+  - **Layer Utilities**: Added Duplicate and Merge controls in the Layer View.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -107,4 +107,5 @@ It will be updated as new sprints add functionality.
     `Discard` button to revert changes.
   - **Layer Utilities**: Duplicate and Merge buttons appear next to the Skip/Ready toggles and refresh the canvas immediately after merging.
   - **Merge Redraw Fix**: The canvas now refreshes after merging layers so merged masks appear immediately.
+  - **Merge Union**: Overlapping regions from merged layers are combined so no pixel is covered by multiple masks in the resulting layer.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -105,5 +105,5 @@ It will be updated as new sprints add functionality.
   - **Auto-Saving Edits**: Mask edits are saved automatically when changing
     layer selection or images. The edit toolbar now features a single
     `Discard` button to revert changes.
-  - **Layer Utilities**: Added Duplicate and Merge controls in the Layer View.
+  - **Layer Utilities**: Duplicate and Merge buttons appear next to the Skip/Ready toggles and refresh the canvas immediately after merging.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -106,5 +106,5 @@ It will be updated as new sprints add functionality.
     layer selection or images. The edit toolbar now features a single
     `Discard` button to revert changes.
   - **Layer Utilities**: Duplicate and Merge buttons appear next to the Skip/Ready toggles and refresh the canvas immediately after merging.
-  - **Merge Redraw Fix**: Merged layers now redraw correctly so masks remain visible without refreshing the page.
+  - **Merge Redraw Fix**: The canvas now refreshes after merging layers so merged masks appear immediately.
 

--- a/docs/annotation_workflow_progress.md
+++ b/docs/annotation_workflow_progress.md
@@ -106,4 +106,5 @@ It will be updated as new sprints add functionality.
     layer selection or images. The edit toolbar now features a single
     `Discard` button to revert changes.
   - **Layer Utilities**: Duplicate and Merge buttons appear next to the Skip/Ready toggles and refresh the canvas immediately after merging.
+  - **Merge Redraw Fix**: Merged layers now redraw correctly so masks remain visible without refreshing the page.
 

--- a/docs/annotation_workflow_specification.md
+++ b/docs/annotation_workflow_specification.md
@@ -93,6 +93,8 @@ This panel sits to the right of the canvas and always reflects the layers for th
     *   **Controls:**
         *   **Select for Edit:** Clicking anywhere on the layer item (except controls) selects it, putting the canvas into **Edit Mode** for this layer. The selected layer should be highlighted.
         *   **Delete Button (Trash Icon):** Permanently removes the layer. Requires confirmation.
+        *   **Duplicate Button:** Creates a copy of the active layer.
+        *   **Merge Button:** Merges all selected layers into the active one, combining masks and labels.
 
 At the bottom of the Layer View, compact buttons allow the user to save an overlay preview of the current image and export the project's annotations to COCO JSON.
 

--- a/docs/annotation_workflow_specification.md
+++ b/docs/annotation_workflow_specification.md
@@ -94,7 +94,7 @@ This panel sits to the right of the canvas and always reflects the layers for th
         *   **Select for Edit:** Clicking anywhere on the layer item (except controls) selects it, putting the canvas into **Edit Mode** for this layer. The selected layer should be highlighted.
         *   **Delete Button (Trash Icon):** Permanently removes the layer. Requires confirmation.
         *   **Duplicate Button:** Creates a copy of the active layer.
-        *   **Merge Button:** Merges all selected layers into the active one, combining masks and labels.
+        *   **Merge Button:** Merges all selected layers into the active one, combining masks and labels. Overlapping mask regions are unioned so the resulting layer has a single mask per pixel.
 
 At the bottom of the Layer View, compact buttons allow the user to save an overlay preview of the current image and export the project's annotations to COCO JSON. Duplicate and Merge utilities appear in this bar next to the image status toggles.
 

--- a/docs/annotation_workflow_specification.md
+++ b/docs/annotation_workflow_specification.md
@@ -96,7 +96,7 @@ This panel sits to the right of the canvas and always reflects the layers for th
         *   **Duplicate Button:** Creates a copy of the active layer.
         *   **Merge Button:** Merges all selected layers into the active one, combining masks and labels.
 
-At the bottom of the Layer View, compact buttons allow the user to save an overlay preview of the current image and export the project's annotations to COCO JSON.
+At the bottom of the Layer View, compact buttons allow the user to save an overlay preview of the current image and export the project's annotations to COCO JSON. Duplicate and Merge utilities appear in this bar next to the image status toggles.
 
 #### 3.1.3. Canvas & Toolbar
 

--- a/docs/annotation_workflow_specification.md
+++ b/docs/annotation_workflow_specification.md
@@ -124,10 +124,9 @@ The canvas interaction will be modal, determined by whether a layer is selected 
         *   **Invert:** Inverts the mask.
         *   **Undo:** Undo last action (Step backward in edit memory).
         *   **Redo:** Redo (Step forward in edit memory).
-        *   **Save:** Save the edits and exit edit mode.
-        *   **Cancel:** Discard edits and exit edit mode.
+        *   **Discard:** Revert changes and exit edit mode.
     
-    A `Save Edit` and `Cancel`: `Save Edit` finalizes the changes to the mask data and sets the layer status to `Edited`. Cancel discards the edits. Both returns the user to Creation Mode (no layer/ empty new layer selected).
+    Edits are automatically saved when leaving edit mode or changing the selected layers. The `Discard` button reverts the masks to their original state without saving.
 
 #### 3.1.4. Image Status & Pool
 


### PR DESCRIPTION
## Summary
- render layer masks with tighter crosshatching
- show solid fill for masks in edit mode
- keep creation mode active after adding masks
- clear predictions when switching images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebe0ce92483208d1e034f241534f9